### PR TITLE
Fixes: swimming and DG big flower functions

### DIFF
--- a/toontown/safezone/DistributedDGFlower.py
+++ b/toontown/safezone/DistributedDGFlower.py
@@ -3,6 +3,7 @@ from direct.distributed.ClockDelta import *
 from direct.distributed import DistributedObject
 from toontown.toonbase import ToontownGlobals
 from direct.task import Task
+from direct.interval.LerpInterval import LerpPosInterval
 SPIN_RATE = 1.25
 
 class DistributedDGFlower(DistributedObject.DistributedObject):
@@ -51,10 +52,20 @@ class DistributedDGFlower(DistributedObject.DistributedObject):
 
     def __flowerEnter(self, collisionEntry):
         self.sendUpdate('avatarEnter', [])
+        self.bigFlowerZ = self.bigFlower.getZ()
+        self.LerpFlowerUp = LerpPosInterval(nodePath=self.bigFlower,
+				                            duration=0.5,
+                                            pos=Point3(1.39, 92.91, self.bigFlowerZ + 2.0),
+                                            )
+
+        self.LerpFlowerUp.start()
 
     def __flowerExit(self, collisionEntry):
         self.sendUpdate('avatarExit', [])
+        self.raisedbigFlowerZ = self.bigFlower.getZ()
+        self.LerpFlowerDown = LerpPosInterval(nodePath=self.bigFlower,
+			                              duration=0.5,
+                                          pos=Point3(1.39, 92.91, self.raisedbigFlowerZ - 2.0),
+				             )
+        self.LerpFlowerDown.start()
 
-    def setHeight(self, newHeight):
-        pos = self.bigFlower.getPos()
-        self.bigFlower.lerpPos(pos[0], pos[1], newHeight, 0.5, task=self.taskName('DG-flowerRaise'))

--- a/toontown/toon/Toon.py
+++ b/toontown/toon/Toon.py
@@ -1662,14 +1662,27 @@ class Toon(Avatar.Avatar, ToonHead):
         taskMgr.remove(swimTaskName)
         self.getGeomNode().setZ(4.0)
         self.nametag3d.setZ(5.0)
-        newTask = Task.loop(self.getGeomNode().lerpPosXYZ(0, -3, 3, 1, blendType='easeInOut'), self.getGeomNode().lerpPosXYZ(0, -3, 4, 1, blendType='easeInOut'))
-        taskMgr.add(newTask, swimTaskName)
+        newTaskstart = LerpPosInterval(nodePath=self.getGeomNode(),
+				                       pos=LPoint3(0, -3, 3),
+				                       startPos=LPoint3(0, -3, 4),
+				                       duration=1.0,
+                                       blendType='easeInOut',
+				                       )
+        newTaskend = LerpPosInterval(nodePath=self.getGeomNode(),
+				                     pos=LPoint3(0, -3, 4),
+				                     startPos=LPoint3(0, -3, 3),
+				                     duration=1.0,
+				                     blendType='easeInOut',
+				                     )
+        self.swimBobTask = Sequence(newTaskstart, newTaskend)
+        self.swimBobTask.loop()
 
     def stopBobSwimTask(self):
         swimTaskName = self.taskName('swimBobTask')
         taskMgr.remove(swimTaskName)
         self.getGeomNode().setPos(0, 0, 0)
         self.nametag3d.setZ(1.0)
+        self.swimBobTask.finish()
 
     def enterOpenBook(self, animMultiplier = 1, ts = 0, callback = None, extraArgs = []):
         Emote.globalEmote.disableAll(self, 'enterOpenBook')


### PR DESCRIPTION
Fixed the swimming lerp function and Daisy Gardens' big flower function, so now toons can cause the big flower to raise when they get near it.

Both of these functions would crash the game before if a toon got near the big flower or started swimming due to the old lerpPos intervals not working anymore.
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/48182689/71439086-330b9a80-26c6-11ea-8f9b-49f080384978.gif)
