### PR TITLE
Make Astron Support option a built-in variable

### DIFF
--- a/otp/ai/AIBase.py
+++ b/otp/ai/AIBase.py
@@ -22,6 +22,7 @@ class AIBase:
     def __init__(self):
         self.config = getConfigShowbase()
         __builtins__['__dev__'] = self.config.GetBool('want-dev', 0)
+        __builtins__['astronSupport'] = self.config.GetBool('astron-support', True)
         logStackDump = (self.config.GetBool('log-stack-dump', (not __dev__)) or self.config.GetBool('ai-log-stack-dump', (not __dev__)))
         uploadStackDump = self.config.GetBool('upload-stack-dump', 0)
         if logStackDump or uploadStackDump:

--- a/otp/distributed/OTPClientRepository.py
+++ b/otp/distributed/OTPClientRepository.py
@@ -175,8 +175,8 @@ class OTPClientRepository(ClientRepositoryBase):
         self.accountOldAuth = config.GetBool('%s-account-old-auth' % game.name,
                                              self.accountOldAuth)
         self.useNewTTDevLogin = base.config.GetBool('use-tt-specific-dev-login', False)
-        self.astronSupport = config.GetBool('astron-support', True)
-        if self.astronSupport:
+        astronSupport = config.GetBool('astron-support', True)
+        if astronSupport:
             self.loginInterface = LoginAstronAccount.LoginAstronAccount(self)
             self.notify.info('loginInterface: LoginAstronAccount')
         elif self.useNewTTDevLogin:
@@ -426,7 +426,7 @@ class OTPClientRepository(ClientRepositoryBase):
         self.__pendingMessages = {}
         self.__doId2pendingInterest = {}
         self.centralLogger = self.generateGlobalObject(OtpDoGlobals.OTP_DO_ID_CENTRAL_LOGGER, 'CentralLogger')
-        if self.astronSupport:
+        if astronSupport:
             self.astronLoginManager = self.generateGlobalObject(OtpDoGlobals.OTP_DO_ID_ASTRON_LOGIN_MANAGER, 'AstronLoginManager')
 
     def startLeakDetector(self):
@@ -524,7 +524,7 @@ class OTPClientRepository(ClientRepositoryBase):
             return
 
         self.startReaderPollTask()
-        if not self.astronSupport:
+        if not astronSupport:
             self.startHeartbeat()
         newInstall = launcher.getIsNewInstallation()
         newInstall = base.config.GetBool('new-installation', newInstall)
@@ -946,7 +946,7 @@ class OTPClientRepository(ClientRepositoryBase):
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def enterWaitForAvatarList(self):
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleWaitForAvatarList
         self._requestAvatarList()
 
@@ -958,7 +958,7 @@ class OTPClientRepository(ClientRepositoryBase):
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def sendGetAvatarsMsg(self):
-        if self.astronSupport:
+        if astronSupport:
             self.astronLoginManager.sendRequestAvatarList()
         else:
             datagram = PyDatagram()
@@ -1077,7 +1077,7 @@ class OTPClientRepository(ClientRepositoryBase):
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def sendCreateAvatarMsg(self, avDNA, avName, avPosition):
-        if self.astronSupport:
+        if astronSupport:
             self.astronLoginManager.sendCreateAvatar(avDNA, avName, avPosition)
         else:
             datagram = PyDatagram()
@@ -1106,14 +1106,14 @@ class OTPClientRepository(ClientRepositoryBase):
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def enterWaitForDeleteAvatarResponse(self, potAv):
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleWaitForDeleteAvatarResponse
         self.sendDeleteAvatarMsg(potAv.id)
         self.waitForDatabaseTimeout(requestName='WaitForDeleteAvatarResponse')
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def sendDeleteAvatarMsg(self, avId):
-        if self.astronSupport:
+        if astronSupport:
             self.astronLoginManager.sendRequestRemoveAvatar(avId)
         else:
             datagram = PyDatagram()
@@ -1157,7 +1157,7 @@ class OTPClientRepository(ClientRepositoryBase):
 
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def enterWaitForSetAvatarResponse(self, potAv):
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleWaitForSetAvatarResponse
         self.sendSetAvatarMsg(potAv)
         self.waitForDatabaseTimeout(requestName='WaitForSetAvatarResponse')
@@ -1177,7 +1177,7 @@ class OTPClientRepository(ClientRepositoryBase):
     def sendSetAvatarIdMsg(self, avId):
         if avId != self.__currentAvId:
             self.__currentAvId = avId
-            if self.astronSupport:
+            if astronSupport:
                 self.astronLoginManager.sendRequestPlayAvatar(avId)
             else:
                 datagram = PyDatagram()
@@ -1446,7 +1446,7 @@ class OTPClientRepository(ClientRepositoryBase):
     @report(types=['args', 'deltaStamp'], dConfigParam='teleport')
     def enterWaitOnEnterResponses(self, shardId, hoodId, zoneId, avId):
         self.cleanGameExit = False
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleWaitOnEnterResponses
         self.handlerArgs = {'hoodId': hoodId,
          'zoneId': zoneId,
@@ -2078,7 +2078,7 @@ class OTPClientRepository(ClientRepositoryBase):
             di = DatagramIterator(dg, di.getCurrentIndex())
             self.deferredGenerates.append((CLIENT_DONE_INTEREST_RESP, (dg, di)))
         else:
-            if self.astronSupport:
+            if astronSupport:
                 # Play back generates, if necessary.
                 # First, create a new DatagramIterator using
                 # the Datagram from DatagramIterator di, and

--- a/toontown/battle/BattlePlace.py
+++ b/toontown/battle/BattlePlace.py
@@ -96,7 +96,7 @@ class BattlePlace(Place.Place):
     def doEnterZone(self, newZoneId):
         if newZoneId != self.zoneId:
             if newZoneId != None:
-                if base.cr.astronSupport:
+                if astronSupport:
                     if hasattr(self, 'zoneVisDict'):
                         visList = self.zoneVisDict[newZoneId]
                     else:

--- a/toontown/distributed/ToontownClientRepository.py
+++ b/toontown/distributed/ToontownClientRepository.py
@@ -178,7 +178,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         del self.okButton
         del self.acceptedText
         del self.acceptedBanner
-        if not self.astronSupport:
+        if not astronSupport:
             datagram = PyDatagram()
             datagram.addUint16(CLIENT_SET_WISHNAME_CLEAR)
             datagram.addUint32(avatarChoice.id)
@@ -198,7 +198,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
 
     def __handleReject(self, avList, index):
         self.rejectDialog.cleanup()
-        if not self.astronSupport:
+        if not astronSupport:
             datagram = PyDatagram()
             datagram.addUint16(CLIENT_SET_WISHNAME_CLEAR)
         avid = 0
@@ -208,7 +208,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
 
         if avid == 0:
             self.notify.error('Avatar rejected not found in avList.  Index is: ' + str(index))
-        if not self.astronSupport:
+        if not astronSupport:
             datagram.addUint32(avid)
             datagram.addUint8(0)
             self.send(datagram)
@@ -321,7 +321,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         self.avCreate = MakeAToon.MakeAToon(self.loginFSM, avList, 'makeAToonComplete', index, self.isPaid())
         self.avCreate.load()
         self.avCreate.enter()
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleCreateAvatar
         self.accept('makeAToonComplete', self.__handleMakeAToon, [avList, index])
         self.accept('nameShopCreateAvatar', self.sendCreateAvatarMsg)
@@ -523,7 +523,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         self.handlerArgs = {'hoodId': hoodId,
          'zoneId': zoneId,
          'avId': avId}
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleTutorialQuestion
         self.__requestSkipTutorial(hoodId, zoneId, avId)
 
@@ -551,7 +551,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         return
 
     def enterTutorialQuestion(self, hoodId, zoneId, avId):
-        if not self.astronSupport:
+        if not astronSupport:
             self.handler = self.handleTutorialQuestion
         self.__requestTutorial(hoodId, zoneId, avId)
 
@@ -870,7 +870,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         self.friendsListError = 0
 
     def sendGetFriendsListRequest(self):
-        if self.astronSupport:
+        if astronSupport:
             print('sendGetFriendsListRequest TODO')
         else:
             self.friendsMapPending = 1
@@ -1097,7 +1097,7 @@ class ToontownClientRepository(OTPClientRepository.OTPClientRepository):
         return True
 
     def sendQuietZoneRequest(self):
-        if self.astronSupport:
+        if astronSupport:
             self.sendSetZoneMsg(OTPGlobals.QuietZone, [])
         else:
             self.sendSetZoneMsg(OTPGlobals.QuietZone)

--- a/toontown/makeatoon/NameShop.py
+++ b/toontown/makeatoon/NameShop.py
@@ -865,7 +865,7 @@ class NameShop(StateData.StateData):
 
     def checkNamePattern(self):
         self.notify.debug('checkNamePattern')
-        if base.cr.astronSupport:
+        if astronSupport:
             base.cr.astronLoginManager.sendSetNamePattern(self.avId,
                                                           self.nameIndices[0], self.nameFlags[0],
                                                           self.nameIndices[1], self.nameFlags[1],
@@ -953,14 +953,14 @@ class NameShop(StateData.StateData):
         self.notify.debug('checkNameTyped')
         if self._submitTypeANameAsPickAName():
             return
-        if not base.cr.astronSupport:
+        if not astronSupport:
             datagram = PyDatagram()
             datagram.addUint16(CLIENT_SET_WISHNAME)
         if justCheck:
             avId = 0
         else:
             avId = self.avId
-        if not base.cr.astronSupport:
+        if not astronSupport:
             datagram.addUint32(avId)
             datagram.addString(self.nameEntry.get())
             messenger.send('nameShopPost', [datagram])
@@ -1082,7 +1082,7 @@ class NameShop(StateData.StateData):
             self.requestingSkipTutorial = False
         if not self.avExists or self.avExists and self.avId == 'deleteMe':
             messenger.send('nameShopCreateAvatar', [style, '', self.index])
-            if base.cr.astronSupport:
+            if astronSupport:
                 self.accept('nameShopCreateAvatarDone', self.handleCreateAvatarResponseMsg)
         else:
             self.checkNameTyped()

--- a/toontown/toonbase/ToontownStart.py
+++ b/toontown/toonbase/ToontownStart.py
@@ -82,6 +82,7 @@ version = OnscreenText(serverVersion, pos=(-1.3, -0.975), scale=0.06, fg=Vec4(0,
 loader.beginBulkLoad('init', TTLocalizer.LoaderLabel, 138, 0, TTLocalizer.TIP_NONE)
 from .ToonBaseGlobal import *
 from direct.showbase.MessengerGlobal import *
+builtins.astronSupport = base.config.GetBool('astron-support', True)
 from toontown.distributed import ToontownClientRepository
 cr = ToontownClientRepository.ToontownClientRepository(serverVersion, launcher)
 cr.music = music

--- a/toontown/town/Street.py
+++ b/toontown/town/Street.py
@@ -355,7 +355,7 @@ class Street(BattlePlace.BattlePlace):
                 if newZoneId != None:
                     self.loader.zoneDict[newZoneId].setColor(0, 0, 1, 1, 100)
             if newZoneId != None:
-                if not base.cr.astronSupport:
+                if not astronSupport:
                     base.cr.sendSetZoneMsg(newZoneId)
                 else:
                     visZones = [self.loader.node2zone[x] for x in self.loader.nodeDict[newZoneId]]

--- a/toontown/town/TownLoader.py
+++ b/toontown/town/TownLoader.py
@@ -73,7 +73,7 @@ class TownLoader(StateData.StateData):
         del self.hood
         del self.nodeDict
         del self.zoneDict
-        if base.cr.astronSupport:
+        if astronSupport:
             del self.node2zone
         del self.fadeInDict
         del self.fadeOutDict
@@ -229,7 +229,7 @@ class TownLoader(StateData.StateData):
     def makeDictionaries(self, dnaStore):
         self.nodeDict = {}
         self.zoneDict = {}
-        if base.cr.astronSupport:
+        if astronSupport:
             self.node2zone = {}
         self.nodeList = []
         self.fadeInDict = {}
@@ -254,7 +254,7 @@ class TownLoader(StateData.StateData):
             self.nodeDict[zoneId] = []
             self.nodeList.append(groupNode)
             self.zoneDict[zoneId] = groupNode
-            if base.cr.astronSupport:
+            if astronSupport:
                 self.node2zone[groupNode] = zoneId
             fadeDuration = 0.5
             self.fadeOutDict[groupNode] = Sequence(Func(groupNode.setTransparency, 1), LerpColorScaleInterval(groupNode, fadeDuration, a0, startColorScale=a1), Func(groupNode.clearColorScale), Func(groupNode.clearTransparency), Func(groupNode.stash), name='fadeZone-' + str(zoneId), autoPause=1)

--- a/toontown/uberdog/ToontownUDRepository.py
+++ b/toontown/uberdog/ToontownUDRepository.py
@@ -29,5 +29,6 @@ class ToontownUDRepository(ToontownInternalRepository):
         self.notify.info('UberDOG server is ready.')
 
     def createGlobals(self):
-        # Create our Astron login manager...
-        self.astronLoginManager = self.generateGlobalObject(OTP_DO_ID_ASTRON_LOGIN_MANAGER, 'AstronLoginManager')
+        if astronSupport:
+            # Create our Astron login manager...
+            self.astronLoginManager = self.generateGlobalObject(OTP_DO_ID_ASTRON_LOGIN_MANAGER, 'AstronLoginManager')


### PR DESCRIPTION
It's more Pythonic to assign `astronSupport` as part of `builtins` instead of assigning it to `OTPClientRepository`.

It's also now assigned in `AIBase`, which means you can use `astronSupport` cases within UD/AI classes.