### PR TITLE
typing: add `__builtins__.pyi` file to append to Python's builtins

### DIFF
--- a/__builtins__.pyi
+++ b/__builtins__.pyi
@@ -1,0 +1,53 @@
+# NOTE: if you modify this file, run `> Python: Restart Language Server` (VSCode)
+# to manually force the typing server to update
+from direct.showbase import DConfig
+from panda3d.core import NodePath
+from typing import Any
+
+from .otp.ai.AIBase import AIBase, Loader
+from .toontown.launcher.ToontownDummyLauncher import ToontownDummyLauncher
+from .toontown.toon.LocalToon import LocalToon
+from .toontown.toonbase.ToonBase import ToonBase
+from .toontown.toonbase.ToontownStart import game as toontownGame
+
+# otp/ai/AIBase.py
+__dev__: bool
+__astron__: bool
+__execWarnings__: bool
+ostream: Any
+globalClock: Any
+vfs: Any | None
+hidden: NodePath
+wantTestObject: bool
+
+# otp/ai/AIBaseGlobal.py
+simbase: AIBase
+run: Any
+taskMgr: Any
+jobMgr: Any
+eventMgr: Any
+messenger: Any
+bboard: Any
+config: DConfig  # type: ignore
+directNotify: Any
+loader: Loader.Loader
+
+def inspect(anObject) -> None: ...
+
+# otp/otpbase/PythonUtil.py
+def pdir() -> None: ...
+def isClient() -> bool: ...
+def lerp(v0: float, v1: float, t: float) -> float: ...
+def triglerp(v0: float, v1: float, t: float) -> float: ...
+def choice(condition: bool, ifTrue: Any, ifFalse: Any) -> Any: ...
+def cmp(a: Any, b: Any) -> Any: ...
+
+# toontown/distributed/ToontownClientRepository.py
+localAvatar: LocalToon
+
+# toontown/toonbase/ToontownStart.py
+game: toontownGame
+launcher: ToontownDummyLauncher
+
+# direct/showbase/ShowBase.py
+base: ToonBase

--- a/__builtins__.pyi
+++ b/__builtins__.pyi
@@ -1,11 +1,10 @@
 # NOTE: if you modify this file, run `> Python: Restart Language Server` (VSCode)
 # to manually force the typing server to update
 from direct.showbase import DConfig
+from direct.showbase.Loader import Loader
 from panda3d.core import NodePath
-from typing import Any
 
-from .otp.ai.AIBase import AIBase, Loader
-from .toontown.launcher.ToontownDummyLauncher import ToontownDummyLauncher
+from .otp.ai.AIBase import AIBase
 from .toontown.toon.LocalToon import LocalToon
 from .toontown.toonbase.ToonBase import ToonBase
 from .toontown.toonbase.ToontownStart import game as toontownGame
@@ -14,40 +13,24 @@ from .toontown.toonbase.ToontownStart import game as toontownGame
 __dev__: bool
 __astron__: bool
 __execWarnings__: bool
-ostream: Any
-globalClock: Any
-vfs: Any | None
 hidden: NodePath
 wantTestObject: bool
 
 # otp/ai/AIBaseGlobal.py
 simbase: AIBase
-run: Any
-taskMgr: Any
-jobMgr: Any
-eventMgr: Any
-messenger: Any
-bboard: Any
 config: DConfig  # type: ignore
-directNotify: Any
-loader: Loader.Loader
-
-def inspect(anObject) -> None: ...
+loader: Loader
 
 # otp/otpbase/PythonUtil.py
-def pdir() -> None: ...
 def isClient() -> bool: ...
 def lerp(v0: float, v1: float, t: float) -> float: ...
 def triglerp(v0: float, v1: float, t: float) -> float: ...
-def choice(condition: bool, ifTrue: Any, ifFalse: Any) -> Any: ...
-def cmp(a: Any, b: Any) -> Any: ...
 
 # toontown/distributed/ToontownClientRepository.py
 localAvatar: LocalToon
 
 # toontown/toonbase/ToontownStart.py
 game: toontownGame
-launcher: ToontownDummyLauncher
 
 # direct/showbase/ShowBase.py
 base: ToonBase


### PR DESCRIPTION
Panda3D and open-toontown add to Python's builtins ~on startup~ [at various points](https://github.com/open-toontown/open-toontown/pull/69#issuecomment-1396384389) at runtime in many places which pyright (VSCode's Python type checker) doesn't natively understand. You can, however, manually change the builtins in `__builtins__.pyi` placed at the root of the repo.

See: https://github.com/microsoft/pyright/blob/main/docs/builtins.md

This PR adds a few common builtins used throughout open-toontown to hopefully ease development. The intention is not for this to be a complete list of additional builtins that Toontown/Panda3D uses, but instead a starter file that can be added to over time.