### PR TITLE
DistributedGolfSpot: Fix ceo golf being ineffective

### DIFF
--- a/toontown/coghq/DistributedGolfSpot.py
+++ b/toontown/coghq/DistributedGolfSpot.py
@@ -716,7 +716,7 @@ class DistributedGolfSpot(DistributedObject.DistributedObject, FSM.FSM):
          throwerId))
         if flyBallCode == ToontownGlobals.PieCodeBossCog and self.avId == localAvatar.doId and self.lastHitSequenceNum != self.__flyBallSequenceNum:
             self.lastHitSequenceNum = self.__flyBallSequenceNum
-            self.boss.d_ballHitBoss(1)
+            self.boss.d_ballHitBoss(2)
         elif flyBallCode == ToontownGlobals.PieCodeToon and self.avId == localAvatar.doId and self.lastHitSequenceNum != self.__flyBallSequenceNum:
             self.lastHitSequenceNum = self.__flyBallSequenceNum
             avatarDoId = entry.getIntoNodePath().getNetTag('avatarDoId')

--- a/toontown/coghq/DistributedGolfSpot.py
+++ b/toontown/coghq/DistributedGolfSpot.py
@@ -716,7 +716,10 @@ class DistributedGolfSpot(DistributedObject.DistributedObject, FSM.FSM):
          throwerId))
         if flyBallCode == ToontownGlobals.PieCodeBossCog and self.avId == localAvatar.doId and self.lastHitSequenceNum != self.__flyBallSequenceNum:
             self.lastHitSequenceNum = self.__flyBallSequenceNum
-            self.boss.d_ballHitBoss(2)
+            if base.config.GetBool('want-ceo-golf-classic-damage', False):
+                self.boss.d_ballHitBoss(1)
+            else:
+                self.boss.d_ballHitBoss(2)
         elif flyBallCode == ToontownGlobals.PieCodeToon and self.avId == localAvatar.doId and self.lastHitSequenceNum != self.__flyBallSequenceNum:
             self.lastHitSequenceNum = self.__flyBallSequenceNum
             avatarDoId = entry.getIntoNodePath().getNetTag('avatarDoId')


### PR DESCRIPTION
This fixes a longtime TTO End of life  bug where ceo golf was ineffective/suboptimal. He would recover damage way too fast for it to be worth it. Fix is either reducing recovery or increasing the damage

