### PR TITLE
Add NPC toons to playgrounds/streets

### DIFF
--- a/toontown/fishing/DistributedFishingPondAI.py
+++ b/toontown/fishing/DistributedFishingPondAI.py
@@ -3,3 +3,13 @@ from direct.distributed.DistributedObjectAI import DistributedObjectAI
 
 class DistributedFishingPondAI(DistributedObjectAI):
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedFishingPondAI')
+
+    def __init__(self, air):
+        DistributedObjectAI.__init__(self, air)
+        self.area = None
+
+    def setArea(self, area):
+        self.area = area
+
+    def getArea(self):
+        return self.area

--- a/toontown/uberdog/DistributedPartyManagerAI.py
+++ b/toontown/uberdog/DistributedPartyManagerAI.py
@@ -3,3 +3,6 @@ from direct.distributed.DistributedObjectAI import DistributedObjectAI
 
 class DistributedPartyManagerAI(DistributedObjectAI):
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedPartyManagerAI')
+
+    def canBuyParties(self):
+        return False  # TODO


### PR DESCRIPTION
Adds the fisherman and party planner toons to the playgrounds and streets. They refuse to talk to players so it doesn't seem to bring up any issues with these features being unimplemented, but it makes the playgrounds a bit less empty.