### PR TITLE
darwin: Remove the direct path to python3.9

### DIFF
--- a/darwin/start-ai-server.sh
+++ b/darwin/start-ai-server.sh
@@ -8,7 +8,7 @@ MESSAGE_DIRECTOR_IP="127.0.0.1:7199"
 EVENT_LOGGER_IP="127.0.0.1:7197"
 DISTRICT_NAME="Toon Valley"
 
-/usr/local/bin/python3.9 -m toontown.ai.AIStart --base-channel ${BASE_CHANNEL} \
+python3.9 -m toontown.ai.AIStart --base-channel ${BASE_CHANNEL} \
                --max-channels ${MAX_CHANNELS} --stateserver ${STATE_SERVER} \
                --messagedirector-ip ${MESSAGE_DIRECTOR_IP} \
                --eventlogger-ip ${EVENT_LOGGER_IP} --district-name "$DISTRICT_NAME"

--- a/darwin/start-game.sh
+++ b/darwin/start-game.sh
@@ -3,4 +3,4 @@ cd ..
 
 export LOGIN_TOKEN=dev
 
-/usr/local/bin/python3.9 -m toontown.launcher.QuickStartLauncher
+python3.9 -m toontown.launcher.QuickStartLauncher

--- a/darwin/start-uberdog-server.sh
+++ b/darwin/start-uberdog-server.sh
@@ -7,7 +7,7 @@ MESSAGE_DIRECTOR_IP="127.0.0.1:7199"
 EVENT_LOGGER_IP="127.0.0.1:7197"
 BASE_CHANNEL=1000000
 
-/usr/local/bin/python3.9 -m toontown.uberdog.UDStart --base-channel ${BASE_CHANNEL} \
+python3.9 -m toontown.uberdog.UDStart --base-channel ${BASE_CHANNEL} \
                --max-channels ${MAX_CHANNELS} --stateserver ${STATE_SERVER} \
                --messagedirector-ip ${MESSAGE_DIRECTOR_IP} \
                --eventlogger-ip ${EVENT_LOGGER_IP}


### PR DESCRIPTION
This allows people to use python3.9 in other places, including a virtual environment inside of the repo