### PR TITLE
Rename unfortunately named variables to be more inclusive.

### DIFF
--- a/toontown/battle/MovieLure.py
+++ b/toontown/battle/MovieLure.py
@@ -98,10 +98,10 @@ def __createFishingPoleMultiTrack(lure, dollar, dollarName):
             suitTrack.append(Func(suit.loop, 'neutral'))
             suitTrack.append(Wait(3.5))
             suitName = suit.getStyleName()
-            retardPos, retardHpr = battle.getActorPosHpr(suit)
-            retardPos.setY(retardPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
+            simulatedPos, simulatedHpr = battle.getActorPosHpr(suit)
+            simulatedPos.setY(simulatedPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
             if suitName in MovieUtil.largeSuits:
-                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, retardPos, battle, trapProp)
+                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, simulatedPos, battle, trapProp)
                 reachTrack = ActorInterval(suit, 'reach', duration=reachAnimDuration)
                 suitTrack.append(Parallel(moveTrack, reachTrack))
             else:

--- a/toontown/battle/MovieLure.py
+++ b/toontown/battle/MovieLure.py
@@ -98,10 +98,10 @@ def __createFishingPoleMultiTrack(lure, dollar, dollarName):
             suitTrack.append(Func(suit.loop, 'neutral'))
             suitTrack.append(Wait(3.5))
             suitName = suit.getStyleName()
-            knockBackedPos, knockBackedHpr = battle.getActorPosHpr(suit)
-            knockBackedPos.setY(knockBackedPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
+            luredPos, luredHpr = battle.getActorPosHpr(suit)
+            luredPos.setY(luredPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
             if suitName in MovieUtil.largeSuits:
-                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, knockBackedPos, battle, trapProp)
+                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, luredPos, battle, trapProp)
                 reachTrack = ActorInterval(suit, 'reach', duration=reachAnimDuration)
                 suitTrack.append(Parallel(moveTrack, reachTrack))
             else:

--- a/toontown/battle/MovieLure.py
+++ b/toontown/battle/MovieLure.py
@@ -98,10 +98,10 @@ def __createFishingPoleMultiTrack(lure, dollar, dollarName):
             suitTrack.append(Func(suit.loop, 'neutral'))
             suitTrack.append(Wait(3.5))
             suitName = suit.getStyleName()
-            simulatedPos, simulatedHpr = battle.getActorPosHpr(suit)
-            simulatedPos.setY(simulatedPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
+            knockBackedPos, knockBackedHpr = battle.getActorPosHpr(suit)
+            knockBackedPos.setY(knockBackedPos.getY() + MovieUtil.SUIT_EXTRA_REACH_DISTANCE)
             if suitName in MovieUtil.largeSuits:
-                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, simulatedPos, battle, trapProp)
+                moveTrack = lerpSuit(suit, 0.0, reachAnimDuration / 2.5, knockBackedPos, battle, trapProp)
                 reachTrack = ActorInterval(suit, 'reach', duration=reachAnimDuration)
                 suitTrack.append(Parallel(moveTrack, reachTrack))
             else:


### PR DESCRIPTION
In "MovieLure.py", under code that handles creating sequences for dollar-bill lures, there are TTO-era variables named "retardPos" and "retardHpr". As you can probably figure out, these don't really feel appropriate to keep in this day and age.
This PR changes these variables to "simulatedPos" and "simulatedHpr" respectively.
As these are simple renames, they don't have any function differences between each other, but just in cause, I have tested and verify that the changes work identically to it's unrenamed counterpart.