### PR TITLE
Fix Photo Fun memory leak

### DIFF
--- a/toontown/minigame/DistributedPhotoGame.py
+++ b/toontown/minigame/DistributedPhotoGame.py
@@ -245,6 +245,11 @@ class DistributedPhotoGame(DistributedMinigame, PhotoGameBase.PhotoGameBase):
         self.removeChildGameFSM(self.gameFSM)
         del self.gameFSM
         self.ignoreAll()
+
+        for rayEntry in self.rayArray:
+            rayEntry[3].remove_node()
+        del self.rayArray
+
         return
 
     def onstage(self):


### PR DESCRIPTION
This PR cleans up the collision nodes created for the camera in Photo Fun, preventing a memory leak.
Fixes #109 