### PR TITLE
Fix missing Shtickerbook model after switching between shorts/skirt

### DIFF
--- a/toontown/toon/Toon.py
+++ b/toontown/toon/Toon.py
@@ -860,6 +860,9 @@ class Toon(Avatar.Avatar, ToonHead):
         self.resetHeight()
         self.setupToonNodes()
         self.generateBackpack()
+        hands = self.getRightHands()
+        for bookActor, hand in zip(self.__bookActors, hands):
+            bookActor.reparentTo(hand)
 
     def generateToonHead(self, copy = 1):
         headHeight = ToonHead.generateToonHead(self, copy, self.style, ('1000', '500', '250'))


### PR DESCRIPTION
This PR fixes the disappearing Shtickerbook after switching torsos by reparenting the book actors when swapping the torso model.
Fixes #108 