### PR TITLE
Tag game bug fixes

### DIFF
--- a/toontown/minigame/DistributedTagGame.py
+++ b/toontown/minigame/DistributedTagGame.py
@@ -1,5 +1,6 @@
 from panda3d.core import *
 from toontown.toonbase.ToonBaseGlobal import *
+from panda3d.otp import NametagGlobals
 from .DistributedMinigame import *
 from direct.interval.IntervalGlobal import *
 from direct.fsm import ClassicFSM, State

--- a/toontown/minigame/DistributedTwoDGame.py
+++ b/toontown/minigame/DistributedTwoDGame.py
@@ -138,8 +138,7 @@ class DistributedTwoDGame(DistributedMinigame):
                 toon.hideName()
                 toon.startSmooth()
                 toon.startLookAround()
-                distCNP = toon.find('**/distAvatarCollNode*')
-                distCNP.node().setIntoCollideMask(BitMask32.allOff())
+                toon.stashBodyCollisions()
                 toonSD = TwoDGameToonSD.TwoDGameToonSD(avId, self)
                 self.toonSDs[avId] = toonSD
                 toonSD.enter()
@@ -255,6 +254,11 @@ class DistributedTwoDGame(DistributedMinigame):
         del self.twoDWalk
         self.twoDDrive = None
         del self.twoDDrive
+
+        for avId in self.remoteAvIdList:
+            toon = self.getAvatar(avId)
+            if toon:
+                toon.unstashBodyCollisions()
         return
 
     def exitCleanup(self):


### PR DESCRIPTION
Fixes a client crash when entering the tag game due to a missing import, and fixes not being able to tag other toons after playing Toon Escape following the solution suggested in #114 