### PR TITLE
config: Remove DConfig

### DIFF
--- a/otp/ai/AIBase.py
+++ b/otp/ai/AIBase.py
@@ -1,6 +1,5 @@
 from panda3d.core import *
 from direct.directnotify.DirectNotifyGlobal import *
-from direct.showbase import DConfig
 from direct.showbase.MessengerGlobal import *
 from direct.showbase.BulletinBoardGlobal import *
 from direct.task.TaskManagerGlobal import *
@@ -21,28 +20,27 @@ class AIBase:
     notify = directNotify.newCategory('AIBase')
 
     def __init__(self):
-        self.config = DConfig
-        __builtins__['__dev__'] = self.config.GetBool('want-dev', 0)
-        __builtins__['__astron__'] = self.config.GetBool('astron-support', 1)
-        __builtins__['__execWarnings__'] = self.config.GetBool('want-exec-warnings', 0)
-        logStackDump = (self.config.GetBool('log-stack-dump', (not __debug__)) or self.config.GetBool('ai-log-stack-dump', (not __debug__)))
-        uploadStackDump = self.config.GetBool('upload-stack-dump', 0)
+        __builtins__['__dev__'] = ConfigVariableBool('want-dev', 0).getValue()
+        __builtins__['__astron__'] = ConfigVariableBool('astron-support', 1).getValue()
+        __builtins__['__execWarnings__'] = ConfigVariableBool('want-exec-warnings', 0).getValue()
+        logStackDump = (ConfigVariableBool('log-stack-dump', (not __debug__)).getValue() or ConfigVariableBool('ai-log-stack-dump', (not __debug__)).getValue())
+        uploadStackDump = ConfigVariableBool('upload-stack-dump', 0).getValue()
         if logStackDump or uploadStackDump:
             ExceptionVarDump.install(logStackDump, uploadStackDump)
-        if self.config.GetBool('use-vfs', 1):
+        if ConfigVariableBool('use-vfs', 1).getValue():
             vfs = VirtualFileSystem.getGlobalPtr()
         else:
             vfs = None
-        self.wantTk = self.config.GetBool('want-tk', 0)
-        self.AISleep = self.config.GetFloat('ai-sleep', 0.04)
-        self.AIRunningNetYield = self.config.GetBool('ai-running-net-yield', 0)
-        self.AIForceSleep = self.config.GetBool('ai-force-sleep', 0)
+        self.wantTk = ConfigVariableBool('want-tk', 0).getValue()
+        self.AISleep = ConfigVariableDouble('ai-sleep', 0.04).getValue()
+        self.AIRunningNetYield = ConfigVariableBool('ai-running-net-yield', 0).getValue()
+        self.AIForceSleep = ConfigVariableBool('ai-force-sleep', 0).getValue()
         self.eventMgr = eventMgr
         self.messenger = messenger
         self.bboard = bulletinBoard
         self.taskMgr = taskMgr
-        Task.TaskManager.taskTimerVerbose = self.config.GetBool('task-timer-verbose', 0)
-        Task.TaskManager.extendedExceptions = self.config.GetBool('extended-exceptions', 0)
+        Task.TaskManager.taskTimerVerbose = ConfigVariableBool('task-timer-verbose', 0).getValue()
+        Task.TaskManager.extendedExceptions = ConfigVariableBool('extended-exceptions', 0).getValue()
         self.sfxManagerList = None
         self.musicManager = None
         self.jobMgr = jobMgr
@@ -61,54 +59,54 @@ class AIBase:
         AIBase.notify.info('__dev__ == %s' % __dev__)
         AIBase.notify.info('__astron__ == %s' % __astron__)
         PythonUtil.recordFunctorCreationStacks()
-        __builtins__['wantTestObject'] = self.config.GetBool('want-test-object', 0)
-        self.wantStats = self.config.GetBool('want-pstats', 0)
-        Task.TaskManager.pStatsTasks = self.config.GetBool('pstats-tasks', 0)
+        __builtins__['wantTestObject'] = ConfigVariableBool('want-test-object', 0).getValue()
+        self.wantStats = ConfigVariableBool('want-pstats', 0).getValue()
+        Task.TaskManager.pStatsTasks = ConfigVariableBool('pstats-tasks', 0).getValue()
         taskMgr.resumeFunc = PStatClient.resumeAfterPause
         defaultValue = 1
         if __dev__:
             defaultValue = 0
-        wantFakeTextures = self.config.GetBool('want-fake-textures-ai', defaultValue)
+        wantFakeTextures = ConfigVariableBool('want-fake-textures-ai', defaultValue).getValue()
         if wantFakeTextures:
             loadPrcFileData('aibase', 'textures-header-only 1')
-        self.wantPets = self.config.GetBool('want-pets', 1)
+        self.wantPets = ConfigVariableBool('want-pets', 1).getValue()
         if self.wantPets:
             if game.name == 'toontown':
                 from toontown.pets import PetConstants
-                self.petMoodTimescale = self.config.GetFloat('pet-mood-timescale', 1.0)
-                self.petMoodDriftPeriod = self.config.GetFloat('pet-mood-drift-period', PetConstants.MoodDriftPeriod)
-                self.petThinkPeriod = self.config.GetFloat('pet-think-period', PetConstants.ThinkPeriod)
-                self.petMovePeriod = self.config.GetFloat('pet-move-period', PetConstants.MovePeriod)
-                self.petPosBroadcastPeriod = self.config.GetFloat('pet-pos-broadcast-period', PetConstants.PosBroadcastPeriod)
-        self.wantBingo = self.config.GetBool('want-fish-bingo', 1)
-        self.wantKarts = self.config.GetBool('wantKarts', 1)
-        self.newDBRequestGen = self.config.GetBool('new-database-request-generate', 1)
-        self.waitShardDelete = self.config.GetBool('wait-shard-delete', 1)
-        self.blinkTrolley = self.config.GetBool('blink-trolley', 0)
-        self.fakeDistrictPopulations = self.config.GetBool('fake-district-populations', 0)
-        self.wantSwitchboard = self.config.GetBool('want-switchboard', 0)
-        self.wantSwitchboardHacks = self.config.GetBool('want-switchboard-hacks', 0)
-        self.GEMdemoWhisperRecipientDoid = self.config.GetBool('gem-demo-whisper-recipient-doid', 0)
-        self.sqlAvailable = self.config.GetBool('sql-available', 1)
+                self.petMoodTimescale = ConfigVariableDouble('pet-mood-timescale', 1.0).getValue()
+                self.petMoodDriftPeriod = ConfigVariableDouble('pet-mood-drift-period', PetConstants.MoodDriftPeriod).getValue()
+                self.petThinkPeriod = ConfigVariableDouble('pet-think-period', PetConstants.ThinkPeriod).getValue()
+                self.petMovePeriod = ConfigVariableDouble('pet-move-period', PetConstants.MovePeriod).getValue()
+                self.petPosBroadcastPeriod = ConfigVariableDouble('pet-pos-broadcast-period', PetConstants.PosBroadcastPeriod).getValue()
+        self.wantBingo = ConfigVariableBool('want-fish-bingo', 1).getValue()
+        self.wantKarts = ConfigVariableBool('wantKarts', 1).getValue()
+        self.newDBRequestGen = ConfigVariableBool('new-database-request-generate', 1).getValue()
+        self.waitShardDelete = ConfigVariableBool('wait-shard-delete', 1).getValue()
+        self.blinkTrolley = ConfigVariableBool('blink-trolley', 0).getValue()
+        self.fakeDistrictPopulations = ConfigVariableBool('fake-district-populations', 0).getValue()
+        self.wantSwitchboard = ConfigVariableBool('want-switchboard', 0).getValue()
+        self.wantSwitchboardHacks = ConfigVariableBool('want-switchboard-hacks', 0).getValue()
+        self.GEMdemoWhisperRecipientDoid = ConfigVariableBool('gem-demo-whisper-recipient-doid', 0).getValue()
+        self.sqlAvailable = ConfigVariableBool('sql-available', 1).getValue()
         self.createStats()
         self.restart()
         return
 
     def setupCpuAffinities(self, minChannel):
         if game.name == 'uberDog':
-            affinityMask = self.config.GetInt('uberdog-cpu-affinity-mask', -1)
+            affinityMask = ConfigVariableInt('uberdog-cpu-affinity-mask', -1).getValue()
         else:
-            affinityMask = self.config.GetInt('ai-cpu-affinity-mask', -1)
+            affinityMask = ConfigVariableInt('ai-cpu-affinity-mask', -1).getValue()
         if affinityMask != -1:
             TrueClock.getGlobalPtr().setCpuAffinity(affinityMask)
         else:
-            autoAffinity = self.config.GetBool('auto-single-cpu-affinity', 0)
+            autoAffinity = ConfigVariableBool('auto-single-cpu-affinity', 0).getValue()
             if game.name == 'uberDog':
-                affinity = self.config.GetInt('uberdog-cpu-affinity', -1)
+                affinity = ConfigVariableInt('uberdog-cpu-affinity', -1).getValue()
                 if autoAffinity and affinity == -1:
                     affinity = 2
             else:
-                affinity = self.config.GetInt('ai-cpu-affinity', -1)
+                affinity = ConfigVariableInt('ai-cpu-affinity', -1).getValue()
                 if autoAffinity and affinity == -1:
                     affinity = 1
             if affinity != -1:

--- a/otp/ai/AIBaseGlobal.py
+++ b/otp/ai/AIBaseGlobal.py
@@ -7,7 +7,6 @@ __builtins__['jobMgr'] = simbase.jobMgr
 __builtins__['eventMgr'] = simbase.eventMgr
 __builtins__['messenger'] = simbase.messenger
 __builtins__['bboard'] = simbase.bboard
-__builtins__['config'] = simbase.config
 __builtins__['directNotify'] = directNotify
 from direct.showbase import Loader
 simbase.loader = Loader.Loader(simbase)

--- a/otp/ai/AIZoneData.py
+++ b/otp/ai/AIZoneData.py
@@ -85,7 +85,7 @@ class AIZoneDataObj:
     def getRender(self):
         if not hasattr(self, '_render'):
             self._render = NodePath('render-%s-%s' % (self._parentId, self._zoneId))
-            if config.GetBool('leak-scene-graph', 0):
+            if ConfigVariableBool('leak-scene-graph', 0).getValue():
                 self._renderLeakDetector = LeakDetectors.SceneGraphLeakDetector(self._render)
         return self._render
 

--- a/otp/ai/BanManagerAI.py
+++ b/otp/ai/BanManagerAI.py
@@ -1,14 +1,14 @@
 import urllib.request, urllib.parse, urllib.error
 import os
-from panda3d.core import HTTPClient, Ramfile
+from panda3d.core import ConfigVariableBool, ConfigVariableString, HTTPClient, Ramfile
 from direct.directnotify import DirectNotifyGlobal
 
 class BanManagerAI:
     notify = DirectNotifyGlobal.directNotify.newCategory('BanManagerAI')
-    BanUrl = simbase.config.GetString('ban-base-url', 'http://vapps.disl.starwave.com:8005/dis-hold/action/event')
-    App = simbase.config.GetString('ban-app-name', 'TTWorldAI')
-    Product = simbase.config.GetString('ban-product', 'Toontown')
-    EventName = simbase.config.GetString('ban-event-name', 'tthackattempt')
+    BanUrl = ConfigVariableString('ban-base-url', 'http://vapps.disl.starwave.com:8005/dis-hold/action/event').getValue()
+    App = ConfigVariableString('ban-app-name', 'TTWorldAI').getValue()
+    Product = ConfigVariableString('ban-product', 'Toontown').getValue()
+    EventName = ConfigVariableString('ban-event-name', 'tthackattempt').getValue()
 
     def __init__(self):
         self.curBanRequestNum = 0
@@ -34,7 +34,7 @@ class BanManagerAI:
          comment,
          fullUrl))
         simbase.air.writeServerEvent('ban_request', avatarId, '%s|%s|%s' % (dislid, comment, fullUrl))
-        if simbase.config.GetBool('do-actual-ban', True):
+        if ConfigVariableBool('do-actual-ban', True).getValue():
             newTaskName = 'ban-task-%d' % self.curBanRequestNum
             newTask = taskMgr.add(self.doBanUrlTask, newTaskName)
             newTask.banRequestNum = self.curBanRequestNum

--- a/otp/ai/TimeManager.py
+++ b/otp/ai/TimeManager.py
@@ -20,14 +20,14 @@ class TimeManager(DistributedObject.DistributedObject):
 
     def __init__(self, cr):
         DistributedObject.DistributedObject.__init__(self, cr)
-        self.updateFreq = base.config.GetFloat('time-manager-freq', 1800)
-        self.minWait = base.config.GetFloat('time-manager-min-wait', 10)
-        self.maxUncertainty = base.config.GetFloat('time-manager-max-uncertainty', 1)
-        self.maxAttempts = base.config.GetInt('time-manager-max-attempts', 5)
-        self.extraSkew = base.config.GetInt('time-manager-extra-skew', 0)
+        self.updateFreq = ConfigVariableDouble('time-manager-freq', 1800).getValue()
+        self.minWait = ConfigVariableDouble('time-manager-min-wait', 10).getValue()
+        self.maxUncertainty = ConfigVariableDouble('time-manager-max-uncertainty', 1).getValue()
+        self.maxAttempts = ConfigVariableInt('time-manager-max-attempts', 5).getValue()
+        self.extraSkew = ConfigVariableInt('time-manager-extra-skew', 0).getValue()
         if self.extraSkew != 0:
             self.notify.info('Simulating clock skew of %0.3f s' % self.extraSkew)
-        self.reportFrameRateInterval = base.config.GetDouble('report-frame-rate-interval', 300.0)
+        self.reportFrameRateInterval = ConfigVariableDouble('report-frame-rate-interval', 300.0).getValue()
         self.talkResult = 0
         self.thisContext = -1
         self.nextContext = 0
@@ -45,7 +45,7 @@ class TimeManager(DistributedObject.DistributedObject):
         DistributedObject.DistributedObject.generate(self)
         self.accept(OTPGlobals.SynchronizeHotkey, self.handleHotkey)
         self.accept('clock_error', self.handleClockError)
-        if __dev__ and base.config.GetBool('enable-garbage-hotkey', 0):
+        if __dev__ and ConfigVariableBool('enable-garbage-hotkey', 0).getValue():
             self.accept(OTPGlobals.DetectGarbageHotkey, self.handleDetectGarbageHotkey)
         if self.updateFreq > 0:
             self.startTask()
@@ -206,7 +206,7 @@ class TimeManager(DistributedObject.DistributedObject):
         if frameRateInterval == 0:
             return
         if not base.frameRateMeter:
-            maxFrameRateInterval = base.config.GetDouble('max-frame-rate-interval', 30.0)
+            maxFrameRateInterval = ConfigVariableDouble('max-frame-rate-interval', 30.0).getValue()
             globalClock.setAverageFrameRateInterval(min(frameRateInterval, maxFrameRateInterval))
         taskMgr.remove('frameRateMonitor')
         taskMgr.doMethodLater(frameRateInterval, self.frameRateMonitor, 'frameRateMonitor')

--- a/otp/chat/ChatInputNormal.py
+++ b/otp/chat/ChatInputNormal.py
@@ -18,9 +18,9 @@ class ChatInputNormal(DirectObject.DirectObject):
         wantHistory = 0
         if __dev__:
             wantHistory = 1
-        self.wantHistory = base.config.GetBool('want-chat-history', wantHistory)
+        self.wantHistory = ConfigVariableBool('want-chat-history', wantHistory).getValue()
         self.history = ['']
-        self.historySize = base.config.GetInt('chat-history-size', 10)
+        self.historySize = ConfigVariableInt('chat-history-size', 10).getValue()
         self.historyIndex = 0
         return
 

--- a/otp/chat/ChatInputTyped.py
+++ b/otp/chat/ChatInputTyped.py
@@ -16,9 +16,9 @@ class ChatInputTyped(DirectObject.DirectObject):
         wantHistory = 0
         if __dev__:
             wantHistory = 1
-        self.wantHistory = base.config.GetBool('want-chat-history', wantHistory)
+        self.wantHistory = ConfigVariableBool('want-chat-history', wantHistory).getValue()
         self.history = ['']
-        self.historySize = base.config.GetInt('chat-history-size', 10)
+        self.historySize = ConfigVariableInt('chat-history-size', 10).getValue()
         self.historyIndex = 0
         return
 
@@ -111,7 +111,7 @@ class ChatInputTyped(DirectObject.DirectObject):
                     pass
             elif self.whisperId:
                 pass
-            elif base.config.GetBool('exec-chat', 0) and text[0] == '>':
+            elif ConfigVariableBool('exec-chat', 0).getValue() and text[0] == '>':
                 text = self.__execMessage(text[1:])
                 base.localAvatar.setChatAbsolute(text, CFSpeech | CFTimeout)
                 return

--- a/otp/chat/ChatInputWhiteListFrame.py
+++ b/otp/chat/ChatInputWhiteListFrame.py
@@ -47,12 +47,12 @@ class ChatInputWhiteListFrame(FSM.FSM, DirectFrame):
         wantHistory = 0
         if __dev__:
             wantHistory = 1
-        self.wantHistory = base.config.GetBool('want-chat-history', wantHistory)
+        self.wantHistory = ConfigVariableBool('want-chat-history', wantHistory).getValue()
         self.history = ['']
-        self.historySize = base.config.GetInt('chat-history-size', 10)
+        self.historySize = ConfigVariableInt('chat-history-size', 10).getValue()
         self.historyIndex = 0
         self.promoteWhiteList = 0
-        self.checkBeforeSend = base.config.GetBool('white-list-check-before-send', 0)
+        self.checkBeforeSend = ConfigVariableBool('white-list-check-before-send', 0).getValue()
         self.whiteList = None
         self.active = 0
         self.autoOff = 0
@@ -194,7 +194,7 @@ class ChatInputWhiteListFrame(FSM.FSM, DirectFrame):
 
         if text:
             self.chatEntry.set('')
-            if base.config.GetBool('exec-chat', 0) and text[0] == '>':
+            if ConfigVariableBool('exec-chat', 0).getValue() and text[0] == '>':
                 text = self.__execMessage(text[1:])
                 base.localAvatar.setChatAbsolute(text, CFSpeech | CFTimeout)
                 return

--- a/otp/distributed/ClsendTracker.py
+++ b/otp/distributed/ClsendTracker.py
@@ -1,18 +1,18 @@
-from panda3d.core import StringStream
+from panda3d.core import ConfigVariableDouble, ConfigVariableInt, StringStream
 from direct.distributed.PyDatagram import PyDatagram
 import random
 
 class ClsendTracker:
     clsendNotify = directNotify.newCategory('clsend')
     NumTrackersLoggingOverflow = 0
-    MaxTrackersLoggingOverflow = config.GetInt('max-clsend-loggers', 5)
+    MaxTrackersLoggingOverflow = ConfigVariableInt('max-clsend-loggers', 5).getValue()
 
     def __init__(self):
         self._logClsendOverflow = False
         if self.isPlayerControlled():
             if simbase.air.getTrackClsends():
                 if ClsendTracker.NumTrackersLoggingOverflow < ClsendTracker.MaxTrackersLoggingOverflow:
-                    self._logClsendOverflow = random.random() < 1.0 / config.GetFloat('clsend-log-one-av-in-every', choice(__dev__, 4, 50))
+                    self._logClsendOverflow = random.random() < 1.0 / ConfigVariableDouble('clsend-log-one-av-in-every', choice(__dev__, 4, 50).getValue())
         if self._logClsendOverflow:
             ClsendTracker.NumTrackersLoggingOverflow += 1
         self._clsendMsgs = []

--- a/otp/friends/GuildManager.py
+++ b/otp/friends/GuildManager.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.DistributedObjectGlobal import DistributedObjectGlobal
 from direct.directnotify.DirectNotifyGlobal import directNotify
 from otp.distributed import OtpDoGlobals
@@ -53,7 +54,7 @@ class GuildManager(DistributedObjectGlobal):
         self.id2Rank = {}
         self.id2Online = {}
         self.pendingMsgs = []
-        self.whiteListEnabled = base.config.GetBool('whitelist-chat-enabled', 1)
+        self.whiteListEnabled = ConfigVariableBool('whitelist-chat-enabled', 1).getValue()
         self.emailNotification = 0
         self.emailNotificationAddress = None
         self.receivingNewList = False

--- a/otp/launcher/DummyLauncherBase.py
+++ b/otp/launcher/DummyLauncherBase.py
@@ -30,7 +30,7 @@ class DummyLauncherBase:
         return
 
     def isTestServer(self):
-        return base.config.GetBool('is-test-server', 0)
+        return ConfigVariableBool('is-test-server', 0).getValue()
 
     def setPhaseComplete(self, phase, percent):
         self.phaseComplete[phase] = percent

--- a/otp/launcher/LauncherBase.py
+++ b/otp/launcher/LauncherBase.py
@@ -3,7 +3,6 @@ import os
 import time
 import builtins
 from panda3d.core import *
-from direct.showbase import DConfig
 from direct.showbase.DirectObject import DirectObject
 from direct.task.MiniTask import MiniTaskManager
 from direct.directnotify.DirectNotifyGlobal import *

--- a/otp/level/DistributedLevel.py
+++ b/otp/level/DistributedLevel.py
@@ -17,7 +17,7 @@ import random
 
 class DistributedLevel(DistributedObject.DistributedObject, Level.Level):
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedLevel')
-    WantVisibility = config.GetBool('level-visibility', 1)
+    WantVisibility = ConfigVariableBool('level-visibility', 1).getValue()
     ColorZonesAllDOs = 0
     FloorCollPrefix = 'zoneFloor'
     OuchTaskName = 'ouchTask'

--- a/otp/level/DistributedLevelAI.py
+++ b/otp/level/DistributedLevelAI.py
@@ -149,7 +149,7 @@ class DistributedLevelAI(DistributedObjectAI.DistributedObjectAI, Level.Level):
             self.modified = 1
             self.scheduleAutosave()
 
-        AutosavePeriod = simbase.config.GetFloat('level-autosave-period-minutes', 5)
+        AutosavePeriod = ConfigVariableDouble('level-autosave-period-minutes', 5).getValue()
 
         def scheduleAutosave(self):
             if hasattr(self, 'autosaveTask'):

--- a/otp/level/EditorGlobals.py
+++ b/otp/level/EditorGlobals.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableString
 from direct.showbase.PythonUtil import uniqueElements
 EditTargetPostName = 'inGameEditTarget'
 EntIdRange = 10000
@@ -14,7 +15,7 @@ username2entIdBase = {'darren': 1 * EntIdRange,
  'rurbino': 11 * EntIdRange}
 usernameConfigVar = 'level-edit-username'
 undefinedUsername = 'UNDEFINED_USERNAME'
-editUsername = config.GetString(usernameConfigVar, undefinedUsername)
+editUsername = ConfigVariableString(usernameConfigVar, undefinedUsername).getValue()
 
 def checkNotReadyToEdit():
     if editUsername == undefinedUsername:

--- a/otp/login/AstronLoginManagerUD.py
+++ b/otp/login/AstronLoginManagerUD.py
@@ -3,6 +3,8 @@ import time
 import os
 from datetime import datetime
 
+from panda3d.core import ConfigVariableString
+
 from direct.directnotify import DirectNotifyGlobal
 from direct.distributed.DistributedObjectGlobalUD import DistributedObjectGlobalUD
 from direct.distributed.PyDatagram import PyDatagram
@@ -45,7 +47,7 @@ class DeveloperAccountDB(AccountDB):
         AccountDB.__init__(self, loginManager)
 
         # Setup the accountToId dictionary
-        self.accountDbFilePath = config.GetString('accountdb-local-file', 'astron/databases/accounts.json')
+        self.accountDbFilePath = ConfigVariableString('accountdb-local-file', 'astron/databases/accounts.json').getValue()
         # Load the JSON file if it exists.
         if os.path.exists(self.accountDbFilePath):
             with open(self.accountDbFilePath, 'r') as file:
@@ -61,7 +63,7 @@ class DeveloperAccountDB(AccountDB):
         if playToken not in self.accountToId:
             # It is not, so we'll associate them with a brand new account object.
             # Get the default access level from config.
-            accessLevel = config.GetString('default-access-level', "SYSTEM_ADMIN")
+            accessLevel = ConfigVariableString('default-access-level', "SYSTEM_ADMIN").getValue()
             if accessLevel not in OTPGlobals.AccessLevelName2Int:
                 self.loginManager.notify.warning(f'Access Level "{accessLevel}" isn\'t defined.  Reverting back to SYSTEM_ADMIN')
                 accessLevel = "SYSTEM_ADMIN"

--- a/otp/login/LoginGSAccount.py
+++ b/otp/login/LoginGSAccount.py
@@ -29,10 +29,10 @@ class LoginGSAccount(LoginBase.LoginBase):
         return 1
 
     def sendLoginMsg(self):
-        DISLID = config.GetInt('fake-DISL-PlayerAccountId', 0)
+        DISLID = ConfigVariableInt('fake-DISL-PlayerAccountId', 0).getValue()
         if not DISLID:
             NameStringId = 'DISLID_%s' % self.loginName
-            DISLID = config.GetInt(NameStringId, 0)
+            DISLID = ConfigVariableInt(NameStringId, 0).getValue()
         cr = self.cr
         datagram = PyDatagram()
         datagram.addUint16(CLIENT_LOGIN)
@@ -49,7 +49,7 @@ class LoginGSAccount(LoginBase.LoginBase):
         datagram.addString(cr.validateDownload)
         datagram.addString(cr.wantMagicWords)
         datagram.addUint32(DISLID)
-        datagram.addString(config.GetString('otp-whitelist', 'YES'))
+        datagram.addString(ConfigVariableString('otp-whitelist', 'YES').getValue())
         cr.send(datagram)
 
     def resendPlayToken(self):

--- a/otp/login/LoginTTAccount.py
+++ b/otp/login/LoginTTAccount.py
@@ -9,7 +9,7 @@ class LoginTTAccount(LoginBase.LoginBase):
 
     def __init__(self, cr):
         LoginBase.LoginBase.__init__(self, cr)
-        self.useTTSpecificLogin = base.config.GetBool('tt-specific-login', 0)
+        self.useTTSpecificLogin = ConfigVariableBool('tt-specific-login', 0).getValue()
         self.notify.info('self.useTTSpecificLogin =%s' % self.useTTSpecificLogin)
 
     def supportsRelogin(self):

--- a/otp/login/LoginTTSpecificDevAccount.py
+++ b/otp/login/LoginTTSpecificDevAccount.py
@@ -32,7 +32,7 @@ class LoginTTSpecificDevAccount(LoginTTAccount.LoginTTAccount):
     def sendLoginMsg(self):
         cr = self.cr
         tokenString = ''
-        access = base.config.GetString('force-paid-status', '')
+        access = ConfigVariableString('force-paid-status', '').getValue()
         if access == '':
             access = 'FULL'
         elif access == 'paid':
@@ -46,7 +46,7 @@ class LoginTTSpecificDevAccount(LoginTTAccount.LoginTTAccount):
         tokenString += 'TOONTOWN_ACCESS=%s&' % access
         tokenString += 'TOONTOWN_GAME_KEY=%s&' % self.loginName
         wlChatEnabled = 'YES'
-        if base.config.GetString('otp-whitelist', 'YES') == 'NO':
+        if ConfigVariableString('otp-whitelist', 'YES').getValue() == 'NO':
             wlChatEnabled = 'NO'
         tokenString += 'WL_CHAT_ENABLED=%s &' % wlChatEnabled
         openChatEnabled = 'NO'
@@ -59,22 +59,22 @@ class LoginTTSpecificDevAccount(LoginTTAccount.LoginTTAccount):
         tokenString += 'CREATE_FRIENDS_WITH_CHAT=%s&' % createFriendsWithChat
         chatCodeCreationRule = 'No'
         if cr.allowSecretChat:
-            if base.config.GetBool('secret-chat-needs-parent-password', 0):
+            if ConfigVariableBool('secret-chat-needs-parent-password', 0).getValue():
                 chatCodeCreationRule = 'PARENT'
             else:
                 chatCodeCreationRule = 'YES'
         tokenString += 'CHAT_CODE_CREATION_RULE=%s&' % chatCodeCreationRule
-        DISLID = config.GetInt('fake-DISL-PlayerAccountId', 0)
+        DISLID = ConfigVariableInt('fake-DISL-PlayerAccountId', 0).getValue()
         if not DISLID:
             NameStringId = 'DISLID_%s' % self.loginName
-            DISLID = config.GetInt(NameStringId, 0)
+            DISLID = ConfigVariableInt(NameStringId, 0).getValue()
         tokenString += 'ACCOUNT_NUMBER=%d&' % DISLID
         tokenString += 'ACCOUNT_NAME=%s&' % self.loginName
         tokenString += 'GAME_USERNAME=%s&' % self.loginName
         tokenString += 'ACCOUNT_NAME_APPROVED=TRUE&'
         tokenString += 'FAMILY_NUMBER=&'
         tokenString += 'Deployment=US&'
-        withParentAccount = base.config.GetBool('dev-with-parent-account', 0)
+        withParentAccount = ConfigVariableBool('dev-with-parent-account', 0).getValue()
         if withParentAccount:
             tokenString += 'TOON_ACCOUNT_TYPE=WITH_PARENT_ACCOUNT&'
         else:
@@ -88,7 +88,7 @@ class LoginTTSpecificDevAccount(LoginTTAccount.LoginTTAccount):
         datagram.addString('dev')
         datagram.addUint32(cr.hashVal)
         datagram.addUint32(4)
-        magicWords = base.config.GetString('want-magic-words', '')
+        magicWords = ConfigVariableString('want-magic-words', '').getValue()
         datagram.addString(magicWords)
         cr.send(datagram)
 

--- a/otp/otpbase/OTPBase.py
+++ b/otp/otpbase/OTPBase.py
@@ -43,7 +43,7 @@ class OTPBase(ShowBase):
         return
 
     def setTaskChainNetThreaded(self):
-        if base.config.GetBool('want-threaded-network', 0):
+        if ConfigVariableBool('want-threaded-network', 0).getValue():
             taskMgr.setupTaskChain('net', numThreads=1, frameBudget=0.001, threadPriority=TPLow)
 
     def setTaskChainNetNonthreaded(self):
@@ -135,7 +135,7 @@ class OTPBase(ShowBase):
         self.pixelZoomCamHistory = 2.0
         self.pixelZoomCamMovedList = []
         self.pixelZoomStarted = None
-        flag = self.config.GetBool('enable-pixel-zoom', True)
+        flag = ConfigVariableBool('enable-pixel-zoom', True).getValue()
         self.enablePixelZoom(flag)
         return
 

--- a/otp/otpbase/PythonUtil.py
+++ b/otp/otpbase/PythonUtil.py
@@ -4,6 +4,8 @@ import math
 import random
 import time
 
+from panda3d.core import ConfigVariableBool
+
 __all__ = ['enumerate', 'nonRepeatingRandomList', 'describeException', 'pdir', 'choice', 'cmp', 'lerp', 'triglerp']
 
 if not hasattr(builtins, 'enumerate'):
@@ -59,10 +61,8 @@ def recordCreationStack(cls):
 # __dev__ is not defined at import time, call this after it's defined
 def recordFunctorCreationStacks():
     global Functor
-    from direct.showbase import DConfig
-    config = DConfig
     # off by default, very slow
-    if __dev__ and config.GetBool('record-functor-creation-stacks', 0):
+    if __dev__ and ConfigVariableBool('record-functor-creation-stacks', 0).getValue():
         if not hasattr(Functor, '_functorCreationStacksRecorded'):
             Functor = recordCreationStackStr(Functor)
             Functor._functorCreationStacksRecorded = True

--- a/otp/speedchat/SpeedChatGMHandler.py
+++ b/otp/speedchat/SpeedChatGMHandler.py
@@ -14,15 +14,15 @@ class SpeedChatGMHandler(DirectObject.DirectObject):
     def generateSCStructure(self):
         SpeedChatGMHandler.scStructure = [OTPLocalizer.PSCMenuGM]
         phraseCount = 0
-        numGMCategories = base.config.GetInt('num-gm-categories', 0)
+        numGMCategories = ConfigVariableInt('num-gm-categories', 0).getValue()
         for i in range(0, numGMCategories):
-            categoryName = base.config.GetString('gm-category-%d' % i, '')
+            categoryName = ConfigVariableString('gm-category-%d' % i, '').getValue()
             if categoryName == '':
                 continue
             categoryStructure = [categoryName]
-            numCategoryPhrases = base.config.GetInt('gm-category-%d-phrases' % i, 0)
+            numCategoryPhrases = ConfigVariableInt('gm-category-%d-phrases' % i, 0).getValue()
             for j in range(0, numCategoryPhrases):
-                phrase = base.config.GetString('gm-category-%d-phrase-%d' % (i, j), '')
+                phrase = ConfigVariableString('gm-category-%d-phrase-%d' % (i, j).getValue(), '')
                 if phrase != '':
                     idx = 'gm%d' % phraseCount
                     SpeedChatGMHandler.scList[idx] = phrase
@@ -31,9 +31,9 @@ class SpeedChatGMHandler(DirectObject.DirectObject):
 
             SpeedChatGMHandler.scStructure.append(categoryStructure)
 
-        numGMPhrases = base.config.GetInt('num-gm-phrases', 0)
+        numGMPhrases = ConfigVariableInt('num-gm-phrases', 0).getValue()
         for i in range(0, numGMPhrases):
-            phrase = base.config.GetString('gm-phrase-%d' % i, '')
+            phrase = ConfigVariableString('gm-phrase-%d' % i, '').getValue()
             if phrase != '':
                 idx = 'gm%d' % phraseCount
                 SpeedChatGMHandler.scList[idx] = phrase

--- a/toontown/ai/CrashedLeaderBoardDecorator.py
+++ b/toontown/ai/CrashedLeaderBoardDecorator.py
@@ -3,7 +3,7 @@ from direct.distributed.ClockDelta import *
 from direct.interval.IntervalGlobal import *
 from . import HolidayDecorator
 from toontown.toonbase import ToontownGlobals
-from panda3d.core import Vec4, CSDefault, TransformState, NodePath, TransparencyAttrib
+from panda3d.core import Vec4, CSDefault, TransformState, NodePath, TransparencyAttrib, ConfigVariableBool
 from panda3d.toontown import loadDNAFile
 from toontown.hood import GSHood
 
@@ -21,7 +21,7 @@ class CrashedLeaderBoardDecorator(HolidayDecorator.HolidayDecorator):
         holidayIds = base.cr.newsManager.getDecorationHolidayId()
         if ToontownGlobals.CRASHED_LEADERBOARD not in holidayIds:
             return
-        if base.config.GetBool('want-crashedLeaderBoard-Smoke', 1):
+        if ConfigVariableBool('want-crashedLeaderBoard-Smoke', 1).getValue():
             self.startSmokeEffect()
 
     def startSmokeEffect(self):
@@ -33,7 +33,7 @@ class CrashedLeaderBoardDecorator(HolidayDecorator.HolidayDecorator):
             base.cr.playGame.getPlace().loader.stopSmokeEffect()
 
     def undecorate(self):
-        if base.config.GetBool('want-crashedLeaderBoard-Smoke', 1):
+        if ConfigVariableBool('want-crashedLeaderBoard-Smoke', 1).getValue():
             self.stopSmokeEffect()
         holidayIds = base.cr.newsManager.getDecorationHolidayId()
         if len(holidayIds) > 0:

--- a/toontown/ai/ToontownAIRepository.py
+++ b/toontown/ai/ToontownAIRepository.py
@@ -61,10 +61,10 @@ class ToontownAIRepository(ToontownInternalRepository):
     def __init__(self, baseChannel, serverId, districtName):
         ToontownInternalRepository.__init__(self, baseChannel, serverId, dcSuffix='AI')
         self.districtName = districtName
-        self.doLiveUpdates = config.GetBool('want-live-updates', True)
-        self.wantCogdominiums = config.GetBool('want-cogdominiums', True)
-        self.useAllMinigames = config.GetBool('want-all-minigames', True)
-        self.dataFolder = config.GetString('server-data-folder', '')
+        self.doLiveUpdates = ConfigVariableBool('want-live-updates', True).getValue()
+        self.wantCogdominiums = ConfigVariableBool('want-cogdominiums', True).getValue()
+        self.useAllMinigames = ConfigVariableBool('want-all-minigames', True).getValue()
+        self.dataFolder = ConfigVariableString('server-data-folder', '').getValue()
         if self.dataFolder:
             self.dataFolder = self.dataFolder + '/'
         self.districtId = None

--- a/toontown/battle/BattleCalculatorAI.py
+++ b/toontown/battle/BattleCalculatorAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from .BattleBase import *
 from .DistributedBattleAI import *
 from toontown.toonbase.ToontownBattleGlobals import *
@@ -27,13 +28,13 @@ class BattleCalculatorAI:
     KBBONUS_LURED_FLAG = 0
     KBBONUS_TGT_LURED = 1
     notify = DirectNotifyGlobal.directNotify.newCategory('BattleCalculatorAI')
-    toonsAlwaysHit = simbase.config.GetBool('toons-always-hit', 0)
-    toonsAlwaysMiss = simbase.config.GetBool('toons-always-miss', 0)
-    toonsAlways5050 = simbase.config.GetBool('toons-always-5050', 0)
-    suitsAlwaysHit = simbase.config.GetBool('suits-always-hit', 0)
-    suitsAlwaysMiss = simbase.config.GetBool('suits-always-miss', 0)
-    immortalSuits = simbase.config.GetBool('immortal-suits', 0)
-    propAndOrganicBonusStack = simbase.config.GetBool('prop-and-organic-bonus-stack', 0)
+    toonsAlwaysHit = ConfigVariableBool('toons-always-hit', 0).getValue()
+    toonsAlwaysMiss = ConfigVariableBool('toons-always-miss', 0).getValue()
+    toonsAlways5050 = ConfigVariableBool('toons-always-5050', 0).getValue()
+    suitsAlwaysHit = ConfigVariableBool('suits-always-hit', 0).getValue()
+    suitsAlwaysMiss = ConfigVariableBool('suits-always-miss', 0).getValue()
+    immortalSuits = ConfigVariableBool('immortal-suits', 0).getValue()
+    propAndOrganicBonusStack = ConfigVariableBool('prop-and-organic-bonus-stack', 0).getValue()
 
     def __init__(self, battle, tutorialFlag=0):
         self.battle = battle
@@ -751,7 +752,7 @@ class BattleCalculatorAI:
         toonId = self.toonAtkOrder[attackIndex]
         attack = self.battle.toonAttacks[toonId]
         atkTrack = self.__getActualTrack(attack)
-        TTOStyle = simbase.config.GetBool('want-tto-style-knockback', False)
+        TTOStyle = ConfigVariableBool('want-tto-style-knockback', False).getValue()
         if atkTrack == HEAL or atkTrack == PETSOS:
             return
         tgts = self.__createToonTargetList(toonId)

--- a/toontown/battle/BattleExperienceAI.py
+++ b/toontown/battle/BattleExperienceAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from toontown.toonbase import ToontownBattleGlobals
 from toontown.suit import SuitDNA
@@ -152,7 +153,7 @@ def assignRewards(activeToons, toonSkillPtsGained, suitsKilled, zoneId, helpfulT
         toon.d_setInventory(toon.inventory.makeNetString())
         toon.b_setAnimState('victory', 1)
 
-        if simbase.air.config.GetBool('battle-passing-no-credit', True):
+        if ConfigVariableBool('battle-passing-no-credit', True).getValue():
             if helpfulToons and toon.doId in helpfulToons:
                 simbase.air.questManager.toonKilledCogs(toon, suitsKilled, zoneId, activeToonList)
                 simbase.air.cogPageManager.toonKilledCogs(toon, suitsKilled, zoneId)

--- a/toontown/battle/BattlePlace.py
+++ b/toontown/battle/BattlePlace.py
@@ -35,7 +35,7 @@ class BattlePlace(Place.Place):
         pass
 
     def enterBattle(self, event):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: COGBATTLE: Enter Battle')
         self.loader.music.stop()
         base.playMusic(self.loader.battleMusic, looping=1, volume=0.9)

--- a/toontown/battle/Movie.py
+++ b/toontown/battle/Movie.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool, ConfigVariableDouble, ConfigVariableString, Point3, Vec3
 from toontown.toonbase.ToontownBattleGlobals import *
 from .BattleBase import *
 from direct.interval.IntervalGlobal import *
@@ -33,7 +34,7 @@ from toontown.toonbase import TTLocalizer
 from toontown.toon import NPCToons
 camPos = Point3(14, 0, 10)
 camHpr = Vec3(89, -30, 0)
-randomBattleTimestamp = base.config.GetBool('random-battle-timestamp', 0)
+randomBattleTimestamp = ConfigVariableBool('random-battle-timestamp', 0).getValue()
 
 class Movie(DirectObject.DirectObject):
     notify = DirectNotifyGlobal.directNotify.newCategory('Movie')
@@ -356,11 +357,11 @@ class Movie(DirectObject.DirectObject):
         self.tutorialTom.setDNA(dna)
         self.tutorialTom.setName(TTLocalizer.NPCToonNames[20000])
         self.tutorialTom.uniqueName = uniqueName
-        if base.config.GetString('language', 'english') == 'japanese':
+        if ConfigVariableString('language', 'english').getValue() == 'japanese':
             self.tomDialogue03 = base.loader.loadSfx('phase_3.5/audio/dial/CC_tom_movie_tutorial_reward01.ogg')
             self.tomDialogue04 = base.loader.loadSfx('phase_3.5/audio/dial/CC_tom_movie_tutorial_reward02.ogg')
             self.tomDialogue05 = base.loader.loadSfx('phase_3.5/audio/dial/CC_tom_movie_tutorial_reward03.ogg')
-            self.musicVolume = base.config.GetFloat('tutorial-music-volume', 0.5)
+            self.musicVolume = ConfigVariableDouble('tutorial-music-volume', 0.5).getValue()
         else:
             self.tomDialogue03 = None
             self.tomDialogue04 = None
@@ -404,7 +405,7 @@ class Movie(DirectObject.DirectObject):
         return
 
     def __doToonAttacks(self):
-        if base.config.GetBool('want-toon-attack-anims', 1):
+        if ConfigVariableBool('want-toon-attack-anims', 1).getValue():
             track = Sequence(name='toon-attacks')
             camTrack = Sequence(name='toon-attacks-cam')
             ival, camIval = MovieFire.doFires(self.__findToonAttack(FIRE))
@@ -879,7 +880,7 @@ class Movie(DirectObject.DirectObject):
         return
 
     def __doSuitAttacks(self):
-        if base.config.GetBool('want-suit-anims', 1):
+        if ConfigVariableBool('want-suit-anims', 1).getValue():
             track = Sequence(name='suit-attacks')
             camTrack = Sequence(name='suit-attacks-cam')
             isLocalToonSad = False

--- a/toontown/battle/MovieLure.py
+++ b/toontown/battle/MovieLure.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.interval.IntervalGlobal import *
 from .BattleBase import *
 from .BattleProps import *
@@ -352,7 +353,7 @@ def __createSuitDamageTrack(battle, suit, hp, lure, trapProp):
         sinkPos1.setZ(sinkPos1.getZ() - 3.1)
         sinkPos2.setZ(sinkPos2.getZ() - 9.1)
         dropPos.setZ(dropPos.getZ() + 15)
-        if base.config.GetBool('want-new-cogs', 0):
+        if ConfigVariableBool('want-new-cogs', 0).getValue():
             nameTag = suit.find('**/def_nameTag')
         else:
             nameTag = suit.find('**/joint_nameTag')

--- a/toontown/battle/MovieSquirt.py
+++ b/toontown/battle/MovieSquirt.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.interval.IntervalGlobal import *
 from .BattleBase import *
 from .BattleProps import *
@@ -282,12 +283,12 @@ def __doFlower(squirt, delay, fShowStun):
     lodnames = toon.getLODNames()
     toonlod0 = toon.getLOD(lodnames[0])
     toonlod1 = toon.getLOD(lodnames[1])
-    if base.config.GetBool('want-new-anims', 1):
+    if ConfigVariableBool('want-new-anims', 1).getValue():
         if not toonlod0.find('**/def_joint_attachFlower').isEmpty():
             flower_joint0 = toonlod0.find('**/def_joint_attachFlower')
     else:
         flower_joint0 = toonlod0.find('**/joint_attachFlower')
-    if base.config.GetBool('want-new-anims', 1):
+    if ConfigVariableBool('want-new-anims', 1).getValue():
         if not toonlod1.find('**/def_joint_attachFlower').isEmpty():
             flower_joint1 = toonlod1.find('**/def_joint_attachFlower')
     else:
@@ -350,7 +351,7 @@ def __doWaterGlass(squirt, delay, fShowStun):
     def getSprayStartPos(toon = toon):
         toon.update(0)
         lod0 = toon.getLOD(toon.getLODNames()[0])
-        if base.config.GetBool('want-new-anims', 1):
+        if ConfigVariableBool('want-new-anims', 1).getValue():
             if not lod0.find('**/def_head').isEmpty():
                 joint = lod0.find('**/def_head')
             else:

--- a/toontown/battle/RewardPanel.py
+++ b/toontown/battle/RewardPanel.py
@@ -1,6 +1,5 @@
 from panda3d.core import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.interval.IntervalGlobal import *
 from toontown.toonbase import ToontownBattleGlobals
 from . import BattleBase
@@ -643,7 +642,7 @@ class RewardPanel(DirectFrame):
                         else:
                             num = quest.doesCogCount(avId, cogDict, zoneId, toonShortList)
                         if num:
-                            if base.config.GetBool('battle-passing-no-credit', True):
+                            if ConfigVariableBool('battle-passing-no-credit', True).getValue():
                                 if avId in helpfulToonsList:
                                     earned += num
                                 else:

--- a/toontown/battle/SuitBattleGlobals.py
+++ b/toontown/battle/SuitBattleGlobals.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableString
 from .BattleBase import *
 import random
 from direct.directnotify import DirectNotifyGlobal
@@ -72,7 +73,7 @@ def pickSuitAttack(attacks, suitLevel):
             break
         index = index + 1
 
-    configAttackName = simbase.config.GetString('attack-type', 'random')
+    configAttackName = ConfigVariableString('attack-type', 'random').getValue()
     if configAttackName == 'random':
         return attackNum
     elif configAttackName == 'sequence':

--- a/toontown/building/DistributedBBElevatorAI.py
+++ b/toontown/building/DistributedBBElevatorAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from .ElevatorConstants import *
 from . import DistributedBossElevatorAI
 
@@ -10,7 +11,7 @@ class DistributedBBElevatorAI(DistributedBossElevatorAI.DistributedBossElevatorA
 
     def checkBoard(self, av):
         result = 0
-        if simbase.config.GetBool('allow-ceo-elevator', 1):
+        if ConfigVariableBool('allow-ceo-elevator', 1).getValue():
             result = DistributedBossElevatorAI.DistributedBossElevatorAI.checkBoard(self, av)
         else:
             result = REJECT_NOT_YET_AVAILABLE

--- a/toontown/building/DistributedBoardingParty.py
+++ b/toontown/building/DistributedBoardingParty.py
@@ -39,7 +39,7 @@ class DistributedBoardingParty(DistributedObject.DistributedObject, BoardingPart
         canonicalZoneId = ZoneUtil.getCanonicalZoneId(self.zoneId)
         self.notify.debug('canonicalZoneId = %s' % canonicalZoneId)
         localAvatar.chatMgr.chatInputSpeedChat.addBoardingGroupMenu(canonicalZoneId)
-        if base.config.GetBool('want-singing', 0):
+        if ConfigVariableBool('want-singing', 0).getValue():
             localAvatar.chatMgr.chatInputSpeedChat.addSingingGroupMenu()
 
     def delete(self):
@@ -136,7 +136,7 @@ class DistributedBoardingParty(DistributedObject.DistributedObject, BoardingPart
                     self.inviterPanels.forceCleanup()
                 self.groupInviteePanel = GroupInvitee.GroupInvitee()
                 self.groupInviteePanel.make(self, inviter, leaderId)
-                if base.config.GetBool('reject-boarding-group-invites', 0):
+                if ConfigVariableBool('reject-boarding-group-invites', 0).getValue():
                     self.groupInviteePanel.forceCleanup()
                     self.groupInviteePanel = None
         return

--- a/toontown/building/DistributedBoardingPartyAI.py
+++ b/toontown/building/DistributedBoardingPartyAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.otpbase import OTPGlobals
 from otp.ai.AIBase import *
 from toontown.toonbase import ToontownGlobals
@@ -94,7 +95,7 @@ class DistributedBoardingPartyAI(DistributedObjectAI.DistributedObjectAI, Boardi
             reason = BoardingPartyBase.BOARDCODE_NOT_PAID
             self.sendUpdateToAvatarId(inviterId, 'postInviteNotQualify', [inviteeId, reason, 0])
             simbase.air.writeServerEvent('suspicious', inviterId, 'User with rights: %s tried to invite someone to a boarding group' % inviter.getGameAccess())
-            if simbase.config.GetBool('want-ban-boardingparty', True):
+            if ConfigVariableBool('want-ban-boardingparty', True).getValue():
                 commentStr = 'User with rights: %s tried to invite someone to a boarding group' % inviter.getGameAccess()
                 dislId = inviter.DISLid
                 simbase.air.banManager.ban(inviterId, dislId, commentStr)

--- a/toontown/building/DistributedBuilding.py
+++ b/toontown/building/DistributedBuilding.py
@@ -343,7 +343,7 @@ class DistributedBuilding(DistributedObject.DistributedObject):
         return
 
     def loadAnimToSuitSfx(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: COGBUILDING: Cog Take Over')
         if self.cogDropSound == None:
             self.cogDropSound = base.loader.loadSfx(self.TAKEOVER_SFX_PREFIX + 'cogbldg_drop.ogg')
@@ -353,7 +353,7 @@ class DistributedBuilding(DistributedObject.DistributedObject):
         return
 
     def loadAnimToToonSfx(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: COGBUILDING: Toon Take Over')
         if self.cogWeakenSound == None:
             self.cogWeakenSound = base.loader.loadSfx(self.TAKEOVER_SFX_PREFIX + 'cogbldg_weaken.ogg')

--- a/toontown/building/DistributedBuildingAI.py
+++ b/toontown/building/DistributedBuildingAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.distributed.ClockDelta import *
 import types
@@ -412,7 +413,7 @@ class DistributedBuildingAI(DistributedObjectAI.DistributedObjectAI):
     def enterToon(self):
         self.d_setState('toon')
         exteriorZoneId, interiorZoneId = self.getExteriorAndInteriorZoneId()
-        if simbase.config.GetBool('want-new-toonhall', 1) and ZoneUtil.getCanonicalZoneId(interiorZoneId) == ToonHall:
+        if ConfigVariableBool('want-new-toonhall', 1).getValue() and ZoneUtil.getCanonicalZoneId(interiorZoneId) == ToonHall:
             self.interior = DistributedToonHallInteriorAI.DistributedToonHallInteriorAI(self.block, self.air, interiorZoneId, self)
         else:
             self.interior = DistributedToonInteriorAI.DistributedToonInteriorAI(self.block, self.air, interiorZoneId, self)

--- a/toontown/building/DistributedClubElevatorAI.py
+++ b/toontown/building/DistributedClubElevatorAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBase import *
 from toontown.toonbase import ToontownGlobals
 from direct.distributed.ClockDelta import *
@@ -11,7 +12,7 @@ class DistributedClubElevatorAI(DistributedElevatorFSMAI.DistributedElevatorFSMA
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedElevatorFloorAI')
     defaultTransitions = {'Off': ['Opening', 'Closed'], 'Opening': ['WaitEmpty', 'WaitCountdown', 'Opening', 'Closing'], 'WaitEmpty': ['WaitCountdown', 'Closing', 'WaitEmpty'], 'WaitCountdown': ['WaitEmpty', 'AllAboard', 'Closing', 'WaitCountdown'], 'AllAboard': ['WaitEmpty', 'Closing'], 'Closing': ['Closed', 'WaitEmpty', 'Closing', 'Opening'], 'Closed': ['Opening']}
     id = 0
-    DoBlockedRoomCheck = simbase.config.GetBool('elevator-blocked-rooms-check', 1)
+    DoBlockedRoomCheck = ConfigVariableBool('elevator-blocked-rooms-check', 1).getValue()
 
     def __init__(self, air, lawOfficeId, bldg, avIds, markerId=None, numSeats=4, antiShuffle=0, minLaff=0):
         DistributedElevatorFSMAI.DistributedElevatorFSMAI.__init__(self, air, bldg, numSeats, antiShuffle=antiShuffle, minLaff=minLaff)

--- a/toontown/building/DistributedDoorAI.py
+++ b/toontown/building/DistributedDoorAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.task.Task import Task
 from direct.distributed.ClockDelta import *
@@ -102,7 +103,7 @@ class DistributedDoorAI(DistributedObjectAI.DistributedObjectAI):
         self.lockedDoor = locked
 
     def isLockedDoor(self):
-        if simbase.config.GetBool('no-locked-doors', 0):
+        if ConfigVariableBool('no-locked-doors', 0).getValue():
             return 0
         else:
             return self.lockedDoor

--- a/toontown/building/DistributedElevatorInt.py
+++ b/toontown/building/DistributedElevatorInt.py
@@ -15,7 +15,7 @@ class DistributedElevatorInt(DistributedElevator.DistributedElevator):
 
     def __init__(self, cr):
         DistributedElevator.DistributedElevator.__init__(self, cr)
-        self.countdownTime = base.config.GetFloat('int-elevator-timeout', INTERIOR_ELEVATOR_COUNTDOWN_TIME)
+        self.countdownTime = ConfigVariableDouble('int-elevator-timeout', INTERIOR_ELEVATOR_COUNTDOWN_TIME).getValue()
 
     def setupElevator(self):
         self.leftDoor = self.bldg.leftDoorOut

--- a/toontown/building/DistributedElevatorIntAI.py
+++ b/toontown/building/DistributedElevatorIntAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from otp.ai.AIBase import *
 from toontown.toonbase import ToontownGlobals
 from direct.distributed.ClockDelta import *
@@ -14,7 +15,7 @@ class DistributedElevatorIntAI(DistributedElevatorAI.DistributedElevatorAI):
 
     def __init__(self, air, bldg, avIds):
         DistributedElevatorAI.DistributedElevatorAI.__init__(self, air, bldg)
-        self.countdownTime = simbase.config.GetFloat('int-elevator-timeout', INTERIOR_ELEVATOR_COUNTDOWN_TIME)
+        self.countdownTime = ConfigVariableDouble('int-elevator-timeout', INTERIOR_ELEVATOR_COUNTDOWN_TIME).getValue()
         self.avIds = copy.copy(avIds)
         for avId in avIds:
             self.acceptOnce(self.air.getAvatarExitEvent(avId), self.__handleAllAvsUnexpectedExit, extraArgs=[avId])

--- a/toontown/building/ElevatorConstants.py
+++ b/toontown/building/ElevatorConstants.py
@@ -19,14 +19,9 @@ REJECT_BOARDINGPARTY = 7
 REJECT_NOTPAID = 8
 MAX_GROUP_BOARDING_TIME = 6.0
 if __dev__:
-    try:
-        config = simbase.config
-    except:
-        config = base.config
-
-    elevatorCountdown = config.GetFloat('elevator-countdown', -1)
-    if elevatorCountdown != -1:
-        bboard.post('elevatorCountdown', elevatorCountdown)
+    elevatorCountdown = ConfigVariableDouble('elevator-countdown')
+    if elevatorCountdown.hasValue():
+        bboard.post('elevatorCountdown', elevatorCountdown.getValue())
 ElevatorData = {ELEVATOR_NORMAL: {'openTime': 2.0,
                    'closeTime': 2.0,
                    'width': 3.5,

--- a/toontown/building/SuitPlannerInteriorAI.py
+++ b/toontown/building/SuitPlannerInteriorAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool, ConfigVariableString
 from otp.ai.AIBaseGlobal import *
 import random, functools
 from toontown.suit import SuitDNA
@@ -9,13 +10,13 @@ class SuitPlannerInteriorAI:
     notify = DirectNotifyGlobal.directNotify.newCategory('SuitPlannerInteriorAI')
 
     def __init__(self, numFloors, bldgLevel, bldgTrack, zone, respectInvasions=1):
-        self.dbg_nSuits1stRound = config.GetBool('n-suits-1st-round', 0)
-        self.dbg_4SuitsPerFloor = config.GetBool('4-suits-per-floor', 0)
-        self.dbg_1SuitPerFloor = config.GetBool('1-suit-per-floor', 0)
+        self.dbg_nSuits1stRound = ConfigVariableBool('n-suits-1st-round', 0).getValue()
+        self.dbg_4SuitsPerFloor = ConfigVariableBool('4-suits-per-floor', 0).getValue()
+        self.dbg_1SuitPerFloor = ConfigVariableBool('1-suit-per-floor', 0).getValue()
         self.zoneId = zone
         self.numFloors = numFloors
         self.respectInvasions = respectInvasions
-        dbg_defaultSuitName = simbase.config.GetString('suit-type', 'random')
+        dbg_defaultSuitName = ConfigVariableString('suit-type', 'random').getValue()
         if dbg_defaultSuitName == 'random':
             self.dbg_defaultSuitType = None
         else:

--- a/toontown/catalog/CatalogGenerator.py
+++ b/toontown/catalog/CatalogGenerator.py
@@ -1568,7 +1568,7 @@ class CatalogGenerator:
             return itemLists
         else:
             self.__releasedItemLists.clear()
-        testDaysAhead = simbase.config.GetInt('test-server-holiday-days-ahead', 0)
+        testDaysAhead = ConfigVariableInt('test-server-holiday-days-ahead', 0).getValue()
         nowtuple = time.localtime(weekStart * 60 + testDaysAhead * 24 * 60 * 60)
         year = nowtuple[0]
         month = nowtuple[1]
@@ -1598,7 +1598,7 @@ class CatalogGenerator:
         itemLists = self.__itemLists.get(dayNumber)
         if itemLists != None:
             return itemLists
-        testDaysAhead = simbase.config.GetInt('test-server-holiday-days-ahead', 0)
+        testDaysAhead = ConfigVariableInt('test-server-holiday-days-ahead', 0).getValue()
         nowtuple = time.localtime(weekStart * 60 + testDaysAhead * 24 * 60 * 60)
         year = nowtuple[0]
         month = nowtuple[1]

--- a/toontown/catalog/CatalogItemPanel.py
+++ b/toontown/catalog/CatalogItemPanel.py
@@ -407,7 +407,7 @@ class CatalogItemPanel(DirectFrame):
         self.accept('verifyDone', self.__handleVerifyPurchase)
 
     def __handleVerifyPurchase(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: Order item')
         status = self.verify.doneStatus
         self.ignore('verifyDone')
@@ -439,7 +439,7 @@ class CatalogItemPanel(DirectFrame):
         self.accept('verifyGiftDone', self.__handleVerifyGift)
 
     def __handleVerifyGift(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: Gift item')
         status = self.verify.doneStatus
         self.ignore('verifyGiftDone')

--- a/toontown/catalog/CatalogScreen.py
+++ b/toontown/catalog/CatalogScreen.py
@@ -1,6 +1,5 @@
 from panda3d.core import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.gui.DirectScrolledList import *
 from toontown.toonbase import ToontownGlobals
 from toontown.toontowngui import TTDialog
@@ -173,7 +172,7 @@ class CatalogScreen(DirectFrame):
         self.emblemCatalogButton['state'] = DGG.DISABLED
 
     def showNewItems(self, index = None):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: New item')
         taskMgr.remove('clarabelleHelpText1')
         messenger.send('wakeup')
@@ -190,7 +189,7 @@ class CatalogScreen(DirectFrame):
         return
 
     def showBackorderItems(self, index = None):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: Backorder item')
         taskMgr.remove('clarabelleHelpText1')
         messenger.send('wakeup')
@@ -207,7 +206,7 @@ class CatalogScreen(DirectFrame):
         return
 
     def showLoyaltyItems(self, index = None):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: Special item')
         taskMgr.remove('clarabelleHelpText1')
         messenger.send('wakeup')
@@ -224,7 +223,7 @@ class CatalogScreen(DirectFrame):
         return
 
     def showEmblemItems(self, index = None):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CATALOG: Emblem item')
         taskMgr.remove('clarabelleHelpText1')
         messenger.send('wakeup')

--- a/toontown/catalog/MailboxScreen.py
+++ b/toontown/catalog/MailboxScreen.py
@@ -176,7 +176,7 @@ class MailboxScreen(DirectObject.DirectObject):
             messenger.send(self.doneEvent)
 
     def __handleAccept(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: MAILBOX: Accept item')
         if self.acceptingIndex != None:
             return

--- a/toontown/char/Char.py
+++ b/toontown/char/Char.py
@@ -3,7 +3,6 @@ from panda3d.core import *
 from panda3d.otp import *
 from direct.task import Task
 import random
-from panda3d.core import *
 from direct.directnotify import DirectNotifyGlobal
 AnimDict = {'mk': (('walk', 'walk', 3),
         ('run', 'run', 3),
@@ -136,12 +135,12 @@ class Char(Avatar.Avatar):
 
     def setLODs(self):
         self.setLODNode()
-        levelOneIn = base.config.GetInt('lod1-in', 50)
-        levelOneOut = base.config.GetInt('lod1-out', 1)
-        levelTwoIn = base.config.GetInt('lod2-in', 100)
-        levelTwoOut = base.config.GetInt('lod2-out', 50)
-        levelThreeIn = base.config.GetInt('lod3-in', 280)
-        levelThreeOut = base.config.GetInt('lod3-out', 100)
+        levelOneIn = ConfigVariableInt('lod1-in', 50).getValue()
+        levelOneOut = ConfigVariableInt('lod1-out', 1).getValue()
+        levelTwoIn = ConfigVariableInt('lod2-in', 100).getValue()
+        levelTwoOut = ConfigVariableInt('lod2-out', 50).getValue()
+        levelThreeIn = ConfigVariableInt('lod3-in', 280).getValue()
+        levelThreeOut = ConfigVariableInt('lod3-out', 100).getValue()
         self.addLOD(LODModelDict[self.style.name][0], levelOneIn, levelOneOut)
         self.addLOD(LODModelDict[self.style.name][1], levelTwoIn, levelTwoOut)
         self.addLOD(LODModelDict[self.style.name][2], levelThreeIn, levelThreeOut)
@@ -411,7 +410,7 @@ class Char(Avatar.Avatar):
         if self.dialogueArray:
             self.notify.warning('loadDialogue() called twice.')
         self.unloadDialogue()
-        language = base.config.GetString('language', 'english')
+        language = ConfigVariableString('language', 'english').getValue()
         if char == 'mk':
             dialogueFile = base.loader.loadSfx('phase_3/audio/dial/mickey.ogg')
             for i in range(0, 6):

--- a/toontown/chat/TTChatInputSpeedChat.py
+++ b/toontown/chat/TTChatInputSpeedChat.py
@@ -344,7 +344,7 @@ class TTChatInputSpeedChat(DirectObject.DirectObject):
         self.insidePartiesMenu = None
         self.createSpeedChat()
         self.whiteList = None
-        self.allowWhiteListSpeedChat = base.config.GetBool('white-list-speed-chat', 0)
+        self.allowWhiteListSpeedChat = ConfigVariableBool('white-list-speed-chat', 0).getValue()
         if self.allowWhiteListSpeedChat:
             self.addWhiteList()
         self.factoryMenu = None
@@ -437,7 +437,7 @@ class TTChatInputSpeedChat(DirectObject.DirectObject):
             self.chatMgr.fsm.request('mainMenu')
 
         self.terminalSelectedEvent = self.speedChat.getEventName(SpeedChatGlobals.SCTerminalSelectedEvent)
-        if base.config.GetBool('want-sc-auto-hide', 1):
+        if ConfigVariableBool('want-sc-auto-hide', 1).getValue():
             self.accept(self.terminalSelectedEvent, selectionMade)
         self.speedChat.reparentTo(aspect2dp, DGG.FOREGROUND_SORT_INDEX)
         scZ = 0.96

--- a/toontown/chat/TTChatInputWhiteList.py
+++ b/toontown/chat/TTChatInputWhiteList.py
@@ -11,7 +11,7 @@ from toontown.toonbase import ToontownGlobals
 
 class TTChatInputWhiteList(ChatInputWhiteListFrame):
     notify = DirectNotifyGlobal.directNotify.newCategory('TTChatInputWhiteList')
-    TFToggleKey = base.config.GetString('true-friend-toggle-key', 'alt')
+    TFToggleKey = ConfigVariableString('true-friend-toggle-key', 'alt').getValue()
     TFToggleKeyUp = TFToggleKey + '-up'
 
     def __init__(self, parent = None, **kw):
@@ -53,7 +53,7 @@ class TTChatInputWhiteList(ChatInputWhiteListFrame):
         self.chatEntry.bind(DGG.OVERFLOW, self.chatOverflow)
         self.chatEntry.bind(DGG.TYPE, self.typeCallback)
         self.trueFriendChat = 0
-        if base.config.GetBool('whisper-to-nearby-true-friends', 1):
+        if ConfigVariableBool('whisper-to-nearby-true-friends', 1).getValue():
             self.accept(self.TFToggleKey, self.shiftPressed)
         return
 
@@ -178,7 +178,7 @@ class TTChatInputWhiteList(ChatInputWhiteListFrame):
         prefixes = []
         if base.cr.magicWordManager and base.cr.wantMagicWords:
             prefixes.append(base.cr.magicWordManager.chatPrefix)
-        if config.GetBool('exec-chat', 0):
+        if ConfigVariableBool('exec-chat', 0).getValue():
             prefixes.append('>')
         if len(text) > 0 and text[0] in prefixes:
             self.okayToSubmit = True

--- a/toontown/chat/ToontownChatManager.py
+++ b/toontown/chat/ToontownChatManager.py
@@ -51,7 +51,7 @@ class ToontownChatManager(ChatManager.ChatManager):
         self.whisperCancelButton = DirectButton(parent=self.whisperFrame, image=(gui.find('**/CloseBtn_UP'), gui.find('**/CloseBtn_DN'), gui.find('**/CloseBtn_Rllvr')), pos=(0.125, 0, -0.1), scale=1.179, relief=None, text=('', OTPLocalizer.ChatManagerCancel, OTPLocalizer.ChatManagerCancel), text_scale=0.05, text_fg=(0, 0, 0, 1), text_pos=(0, -0.09), textMayChange=0, command=self.__whisperCancelPressed)
         gui.removeNode()
         ChatManager.ChatManager.__init__(self, cr, localAvatar)
-        self.defaultToWhiteList = base.config.GetBool('white-list-is-default', 1)
+        self.defaultToWhiteList = ConfigVariableBool('white-list-is-default', 1).getValue()
         self.chatInputSpeedChat = TTChatInputSpeedChat(self)
         self.normalPos = Vec3(-1.083, 0, 0.804)
         self.whisperPos = Vec3(0.0, 0, 0.71)
@@ -364,7 +364,7 @@ class ToontownChatManager(ChatManager.ChatManager):
         self.problemActivatingChat.hide()
 
     def __normalButtonPressed(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CHAT: Speedchat Plus')
         messenger.send('wakeup')
         if base.cr.productName in ['DisneyOnline-US', 'ES']:
@@ -407,7 +407,7 @@ class ToontownChatManager(ChatManager.ChatManager):
             print('ChatManager: productName: %s not recognized' % base.cr.productName)
 
     def __scButtonPressed(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CHAT: Speedchat')
         messenger.send('wakeup')
         if self.fsm.getCurrentState().getName() == 'speedChat':
@@ -493,7 +493,7 @@ class ToontownChatManager(ChatManager.ChatManager):
         self.fsm.request('mainMenu')
 
     def __whisperScButtonPressed(self, avatarName, avatarId, playerId):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: CHAT: Whisper')
         messenger.send('wakeup')
         hasManager = hasattr(base.cr, 'playerFriendsManager')

--- a/toontown/classicchars/DistributedCCharBaseAI.py
+++ b/toontown/classicchars/DistributedCCharBaseAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.distributed.ClockDelta import *
 from otp.avatar import DistributedAvatarAI
@@ -20,7 +21,7 @@ class DistributedCCharBaseAI(DistributedAvatarAI.DistributedAvatarAI):
 
     def generate(self):
         DistributedAvatarAI.DistributedAvatarAI.generate(self)
-        if config.GetBool('classic-char-client-spam', 0):
+        if ConfigVariableBool('classic-char-client-spam', 0).getValue():
             self._ccharSpamTask = taskMgr.add(self._simSpam, 'cchar-spam-%s' % serialNum())
 
     def _simSpam(self, task):

--- a/toontown/coderedemption/TTCodeRedemptionConsts.py
+++ b/toontown/coderedemption/TTCodeRedemptionConsts.py
@@ -1,3 +1,5 @@
+from panda3d.core import ConfigVariableInt
+
 DefaultDbName = 'tt_code_redemption'
 RedeemErrors = Enum('Success, CodeDoesntExist, CodeIsInactive, CodeAlreadyRedeemed, AwardCouldntBeGiven, TooManyAttempts, SystemUnavailable, ')
 RedeemErrorStrings = {RedeemErrors.Success: 'Success',
@@ -7,4 +9,4 @@ RedeemErrorStrings = {RedeemErrors.Success: 'Success',
  RedeemErrors.AwardCouldntBeGiven: 'Award could not be given',
  RedeemErrors.TooManyAttempts: 'Too many attempts, code ignored',
  RedeemErrors.SystemUnavailable: 'Code redemption is currently unavailable'}
-MaxCustomCodeLen = config.GetInt('tt-max-custom-code-len', 16)
+MaxCustomCodeLen = ConfigVariableInt('tt-max-custom-code-len', 16).getValue()

--- a/toontown/cogdominium/CogdoFlyingCollisions.py
+++ b/toontown/cogdominium/CogdoFlyingCollisions.py
@@ -1,5 +1,5 @@
 from direct.controls.GravityWalker import GravityWalker
-from panda3d.core import CollisionSphere, CollisionNode, BitMask32, CollisionHandlerEvent, CollisionRay, CollisionHandlerGravity, CollisionHandlerFluidPusher, CollisionHandlerPusher
+from panda3d.core import CollisionSphere, CollisionNode, BitMask32, CollisionHandlerEvent, CollisionRay, CollisionHandlerGravity, CollisionHandlerFluidPusher, CollisionHandlerPusher, ConfigVariableBool
 from toontown.toonbase import ToontownGlobals
 from otp.otpbase import OTPGlobals
 
@@ -25,7 +25,7 @@ class CogdoFlyingCollisions(GravityWalker):
         cSphereNodePath = self.avatarNodePath.attachNewNode(cSphereNode)
         cSphereNode.setFromCollideMask(bitmask)
         cSphereNode.setIntoCollideMask(BitMask32.allOff())
-        if config.GetBool('want-fluid-pusher', 0):
+        if ConfigVariableBool('want-fluid-pusher', 0).getValue():
             self.pusher = CollisionHandlerFluidPusher()
         else:
             self.pusher = CollisionHandlerPusher()

--- a/toontown/cogdominium/CogdoFlyingGame.py
+++ b/toontown/cogdominium/CogdoFlyingGame.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.showbase.DirectObject import DirectObject
 from direct.task.Task import Task
 from direct.showbase.RandomNumGen import RandomNumGen
@@ -160,7 +161,7 @@ class CogdoFlyingGame(DirectObject):
         self.acceptOnce(CogdoFlyingLocalPlayer.RanOutOfTimeEventName, self.handleLocalPlayerRanOutOfTime)
         self.__startUpdateTask()
         self.isGameComplete = False
-        if __debug__ and base.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.acceptOnce('end', self.guiMgr.forceTimerDone)
 
             def toggleFog():
@@ -192,7 +193,7 @@ class CogdoFlyingGame(DirectObject):
         self.ignore(CogdoFlyingLegalEagle.RequestAddTargetAgainEventName)
         self.ignore(CogdoFlyingLegalEagle.RequestRemoveTargetEventName)
         self.ignore(CogdoFlyingLocalPlayer.PlayWaitingMusicEventName)
-        if __debug__ and base.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.ignore('end')
             self.ignore('home')
         self.level.update(0.0)

--- a/toontown/cogdominium/CogdoMaze.py
+++ b/toontown/cogdominium/CogdoMaze.py
@@ -1,4 +1,4 @@
-from panda3d.core import NodePath, VBase4
+from panda3d.core import ConfigVariableBool, NodePath, VBase4
 from direct.showbase.DirectObject import DirectObject
 from direct.showbase.RandomNumGen import RandomNumGen
 from toontown.minigame.MazeBase import MazeBase
@@ -18,7 +18,7 @@ class CogdoMaze(MazeBase, DirectObject):
         self._clearColor = VBase4(base.win.getClearColor())
         self._clearColor.setW(1.0)
         base.win.setClearColor(VBase4(0.0, 0.0, 0.0, 1.0))
-        if __debug__ and base.config.GetBool('cogdomaze-dev', False):
+        if __debug__ and ConfigVariableBool('cogdomaze-dev', False).getValue():
             self._initCollisionVisuals()
 
     def _initWaterCoolers(self):

--- a/toontown/cogdominium/CogdoMazeGame.py
+++ b/toontown/cogdominium/CogdoMazeGame.py
@@ -1,4 +1,4 @@
-from panda3d.core import Point3, CollisionSphere, CollisionNode
+from panda3d.core import Point3, CollisionSphere, CollisionNode, ConfigVariableBool
 from direct.showbase.DirectObject import DirectObject
 from direct.showbase.PythonUtil import Functor
 from direct.showbase.RandomNumGen import RandomNumGen
@@ -26,7 +26,7 @@ class CogdoMazeGame(DirectObject):
 
     def __init__(self, distGame):
         self.distGame = distGame
-        self._allowSuitsHitToons = base.config.GetBool('cogdomaze-suits-hit-toons', True)
+        self._allowSuitsHitToons = ConfigVariableBool('cogdomaze-suits-hit-toons', True).getValue()
 
     def load(self, cogdoMazeFactory, numSuits, bossCode):
         self._initAudio()

--- a/toontown/cogdominium/CogdoUtil.py
+++ b/toontown/cogdominium/CogdoUtil.py
@@ -1,4 +1,4 @@
-from panda3d.core import ColorBlendAttrib
+from panda3d.core import ColorBlendAttrib, ConfigVariableBool
 ModelPhase = 5
 ModelTypes = {'animation': 'a',
  'model': 'm',
@@ -39,7 +39,7 @@ class VariableContainer:
 class DevVariableContainer:
 
     def __init__(self, name):
-        self.__dict__['_enabled'] = config.GetBool('%s-dev' % name, False)
+        self.__dict__['_enabled'] = ConfigVariableBool('%s-dev' % name, False).getValue()
 
     def __setattr__(self, name, value):
         self.__dict__[name] = self._enabled and value

--- a/toontown/cogdominium/DistCogdoFlyingGame.py
+++ b/toontown/cogdominium/DistCogdoFlyingGame.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.ClockDelta import globalClockDelta
 from toontown.toonbase import TTLocalizer
 from .CogdoFlyingGame import CogdoFlyingGame
@@ -10,7 +11,7 @@ class DistCogdoFlyingGame(DistCogdoGame):
 
     def __init__(self, cr):
         DistCogdoGame.__init__(self, cr)
-        if __debug__ and base.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.accept('onCodeReload', self.__sgOnCodeReload)
         self.game = CogdoFlyingGame(self)
 

--- a/toontown/cogdominium/DistCogdoFlyingGameAI.py
+++ b/toontown/cogdominium/DistCogdoFlyingGameAI.py
@@ -1,4 +1,5 @@
 import random
+from panda3d.core import ConfigVariableBool
 from direct.distributed.ClockDelta import globalClockDelta
 from .DistCogdoGameAI import DistCogdoGameAI
 from . import CogdoFlyingGameGlobals as Globals
@@ -20,7 +21,7 @@ class DistCogdoFlyingGameAI(DistCogdoGameAI):
         self.broadcastedGotoWinState = False
         self.broadcastedGameFinished = False
         self._gameState = False
-        if __debug__ and simbase.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.accept('onCodeReload', self._DistCogdoFlyingGameAI__sgOnCodeReload)
 
     def getLegalEagleAttackRoundTime(self, fromCooldown = False):

--- a/toontown/cogdominium/DistCogdoGame.py
+++ b/toontown/cogdominium/DistCogdoGame.py
@@ -1,4 +1,4 @@
-from panda3d.core import VBase4
+from panda3d.core import ConfigVariableBool, VBase4
 from direct.gui.DirectGui import DirectLabel
 from direct.directnotify.DirectNotifyGlobal import directNotify
 from direct.distributed.ClockDelta import globalClockDelta
@@ -11,7 +11,7 @@ from toontown.minigame.MinigameRulesPanel import MinigameRulesPanel
 from toontown.cogdominium.CogdoGameRulesPanel import CogdoGameRulesPanel
 from toontown.minigame import MinigameGlobals
 from toontown.toonbase import TTLocalizer as TTL
-SCHELLGAMES_DEV = __debug__ and base.config.GetBool('schellgames-dev', False)
+SCHELLGAMES_DEV = __debug__ and ConfigVariableBool('schellgames-dev', False).getValue()
 
 class DistCogdoGame(DistCogdoGameBase, DistributedObject):
     notify = directNotify.newCategory('DistCogdoGame')

--- a/toontown/cogdominium/DistCogdoGameAI.py
+++ b/toontown/cogdominium/DistCogdoGameAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify.DirectNotifyGlobal import directNotify
 from direct.distributed.ClockDelta import globalClockDelta
 from direct.distributed.DistributedObjectAI import DistributedObjectAI
@@ -12,7 +13,7 @@ class SadCallbackToken:
 
 class DistCogdoGameAI(DistCogdoGameBase, DistributedObjectAI):
     notify = directNotify.newCategory('DistCogdoGameAI')
-    EndlessCogdoGames = simbase.config.GetBool('endless-cogdo-games', 0)
+    EndlessCogdoGames = ConfigVariableBool('endless-cogdo-games', 0).getValue()
 
     def __init__(self, air, interior):
         DistributedObjectAI.__init__(self, air)

--- a/toontown/cogdominium/DistCogdoMazeGame.py
+++ b/toontown/cogdominium/DistCogdoMazeGame.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.ClockDelta import globalClockDelta
 from toontown.toonbase import TTLocalizer
 from .DistCogdoGame import DistCogdoGame
@@ -14,7 +15,7 @@ class DistCogdoMazeGame(DistCogdoGame, DistCogdoMazeGameBase):
         DistCogdoGame.__init__(self, cr)
         self.game = CogdoMazeGame(self)
         self._numSuits = (0, 0, 0)
-        if __debug__ and base.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.accept('onCodeReload', self.__sgOnCodeReload)
 
     def delete(self):

--- a/toontown/cogdominium/DistCogdoMazeGameAI.py
+++ b/toontown/cogdominium/DistCogdoMazeGameAI.py
@@ -1,4 +1,4 @@
-from panda3d.core import Vec3, NodePath
+from panda3d.core import ConfigVariableBool, ConfigVariableDouble, Vec3, NodePath
 from direct.distributed.ClockDelta import globalClockDelta
 from otp.avatar.SpeedMonitor import SpeedMonitor
 from toontown.cogdominium.CogdoMaze import CogdoMazeFactory
@@ -16,7 +16,7 @@ class DistCogdoMazeGameAI(DistCogdoGameAI, DistCogdoMazeGameBase):
     TimeoutTimerTaskName = 'CMG_timeoutTimerTask'
     CountdownTimerTaskName = 'CMG_countdownTimerTask'
     AnnounceGameDoneTimerTaskName = 'CMG_AnnounceGameDoneTimerTask'
-    SkipCogdoGames = simbase.config.GetBool('skip-cogdo-game', 0)
+    SkipCogdoGames = ConfigVariableBool('skip-cogdo-game', 0).getValue()
 
     def __init__(self, air, id):
         DistCogdoGameAI.__init__(self, air, id)
@@ -33,7 +33,7 @@ class DistCogdoMazeGameAI(DistCogdoGameAI, DistCogdoMazeGameBase):
         self.jokeLastRequestId = None
         self.jokeRequestStartTime = globalClock.getFrameTime()
         self.jokeRequestCount = None
-        if __debug__ and simbase.config.GetBool('schellgames-dev', True):
+        if __debug__ and ConfigVariableBool('schellgames-dev', True).getValue():
             self.accept('onCodeReload', self.__sgOnCodeReload)
 
     def setExteriorZone(self, exteriorZone):
@@ -125,7 +125,7 @@ class DistCogdoMazeGameAI(DistCogdoGameAI, DistCogdoMazeGameBase):
                 secondsPerGrab = elapsed / self.requestCount
                 if self.requestCount >= 3 and secondsPerGrab <= 0.4:
                     simbase.air.writeServerEvent('suspicious', avId, 'suitHit %s suits in %s seconds' % (self.requestCount, elapsed))
-                    if simbase.config.GetBool('want-ban-cogdo-maze-suit-hit', False):
+                    if ConfigVariableBool('want-ban-cogdo-maze-suit-hit', False).getValue():
                         toon.ban('suitHit %s suits in %s seconds' % (self.requestCount, elapsed))
 
                     result = False
@@ -372,7 +372,7 @@ class DistCogdoMazeGameAI(DistCogdoGameAI, DistCogdoMazeGameBase):
                 secondsPerGrab = elapsed / self.jokeRequestCount
                 if self.jokeRequestCount >= 4 and secondsPerGrab <= 0.03:
                     simbase.air.writeServerEvent('suspicious', senderId, 'requestPickup %s jokes in %s seconds' % (self.jokeRequestCount, elapsed))
-                    if simbase.config.GetBool('want-ban-cogdo-maze-request-pickup', False):
+                    if ConfigVariableBool('want-ban-cogdo-maze-request-pickup', False).getValue():
                         toon.ban('requestPickup %s jokes in %s seconds' % (self.jokeRequestCount, elapsed))
 
                     result = False
@@ -400,14 +400,14 @@ class DistCogdoMazeGameAI(DistCogdoGameAI, DistCogdoMazeGameBase):
             if toon:
                 token = self._speedMonitor.addNodepath(toon)
                 self._toonId2speedToken[toonId] = token
-                self._speedMonitor.setSpeedLimit(token, config.GetFloat('cogdo-maze-speed-limit', Globals.ToonRunSpeed * 1.1), Functor(self._toonOverSpeedLimit, toonId))
+                self._speedMonitor.setSpeedLimit(token, ConfigVariableDouble('cogdo-maze-speed-limit', Globals.ToonRunSpeed * 1.1).getValue(), Functor(self._toonOverSpeedLimit, toonId))
 
     def _toonOverSpeedLimit(self, toonId, speed):
-        self._bootPlayerForHacking(toonId, 'speeding in cogdo maze game (%.2f feet/sec)' % speed, config.GetBool('want-ban-cogdo-maze-speeding', 0))
+        self._bootPlayerForHacking(toonId, 'speeding in cogdo maze game (%.2f feet/sec)' % speed, ConfigVariableBool('want-ban-cogdo-maze-speeding', 0).getValue())
 
     def _toonHackingRequestGag(self, toonId):
         simbase.air.writeServerEvent('suspicious', toonId, 'CogdoMazeGame: toon caught hacking requestGag')
-        self._bootPlayerForHacking(toonId, 'hacking cogdo maze game requestGag', config.GetBool('want-ban-cogdo-maze-requestgag-hacking', 0))
+        self._bootPlayerForHacking(toonId, 'hacking cogdo maze game requestGag', ConfigVariableBool('want-ban-cogdo-maze-requestgag-hacking', 0).getValue())
 
     def _bootPlayerForHacking(self, toonId, reason, wantBan):
         toon = simbase.air.doId2do.get(toonId)

--- a/toontown/cogdominium/DistributedCogdoInterior.py
+++ b/toontown/cogdominium/DistributedCogdoInterior.py
@@ -3,7 +3,7 @@ from direct.interval.IntervalGlobal import *
 from direct.distributed.ClockDelta import *
 from toontown.building.ElevatorConstants import *
 from toontown.toon import NPCToons
-from panda3d.core import NodePath
+from panda3d.core import ConfigVariableBool, NodePath
 from panda3d.otp import *
 from toontown.building import ElevatorUtils
 from toontown.toonbase import ToontownGlobals
@@ -41,7 +41,7 @@ class DistributedCogdoInterior(DistributedObject.DistributedObject):
         self.reserveSuits = []
         self.joiningReserves = []
         self.distBldgDoId = None
-        self._CogdoGameRepeat = config.GetBool('cogdo-game-repeat', 0)
+        self._CogdoGameRepeat = ConfigVariableBool('cogdo-game-repeat', 0).getValue()
         self.currentFloor = -1
         self.elevatorName = self.__uniqueName('elevator')
         self.floorModel = None
@@ -70,7 +70,7 @@ class DistributedCogdoInterior(DistributedObject.DistributedObject):
          120,
          12,
          38]
-        self._wantBarrelRoom = config.GetBool('cogdo-want-barrel-room', 0)
+        self._wantBarrelRoom = ConfigVariableBool('cogdo-want-barrel-room', 0).getValue()
         self.barrelRoom = CogdoBarrelRoom.CogdoBarrelRoom()
         self.brResults = [[], []]
         self.barrelRoomIntroTrack = None

--- a/toontown/cogdominium/DistributedCogdoInteriorAI.py
+++ b/toontown/cogdominium/DistributedCogdoInteriorAI.py
@@ -1,5 +1,6 @@
 import copy
 import random
+from panda3d.core import ConfigVariableBool, ConfigVariableString
 from direct.directnotify import DirectNotifyGlobal
 from direct.distributed import DistributedObjectAI
 from direct.distributed.ClockDelta import *
@@ -34,7 +35,7 @@ IntGames = set([
     'crane',
     'flying',
     'defense'])
-simbase.forcedCogdoGame = config.GetString('cogdo-game', '')
+simbase.forcedCogdoGame = ConfigVariableString('cogdo-game', '').getValue()
 GameRequests = {}
 
 class DistributedCogdoInteriorAI(DistributedObjectAI.DistributedObjectAI):
@@ -67,7 +68,7 @@ class DistributedCogdoInteriorAI(DistributedObjectAI.DistributedObjectAI):
         self.bldg = elevator.bldg
         self.elevator = elevator
         self._game = None
-        self._CogdoGameRepeat = config.GetBool('cogdo-game-repeat', 0)
+        self._CogdoGameRepeat = ConfigVariableBool('cogdo-game-repeat', 0).getValue()
         self.suits = []
         self.activeSuits = []
         self.reserveSuits = []
@@ -76,7 +77,7 @@ class DistributedCogdoInteriorAI(DistributedObjectAI.DistributedObjectAI):
         self.suitsKilledPerFloor = []
         self.battle = None
         self.timer = Timer.Timer()
-        self._wantBarrelRoom = config.GetBool('cogdo-want-barrel-room', 0)
+        self._wantBarrelRoom = ConfigVariableBool('cogdo-want-barrel-room', 0).getValue()
         self.barrelRoom = None
         self.responses = {}
         self.ignoreResponses = 0
@@ -533,7 +534,7 @@ class DistributedCogdoInteriorAI(DistributedObjectAI.DistributedObjectAI):
         for (toonId, penalty) in self._penaltyLaff.items():
             if penalty:
                 av = self.air.doId2do.get(toonId)
-                if config.GetBool('want-cogdo-maze-no-sad', 1):
+                if ConfigVariableBool('want-cogdo-maze-no-sad', 1).getValue():
                     avHp = av.getHp()
                     if avHp < 1:
                         avHp = 1

--- a/toontown/coghq/BossbotCogHQLoader.py
+++ b/toontown/coghq/BossbotCogHQLoader.py
@@ -10,7 +10,7 @@ from toontown.coghq import BossbotHQExterior
 from toontown.coghq import BossbotHQBossBattle
 from toontown.coghq import BossbotOfficeExterior
 from toontown.coghq import CountryClubInterior
-from panda3d.core import DecalEffect, TextEncoder
+from panda3d.core import ConfigVariableBool, DecalEffect, TextEncoder
 import random
 aspectSF = 0.7227
 
@@ -55,7 +55,7 @@ class BossbotCogHQLoader(CogHQLoader.CogHQLoader):
             origin = top.find('**/tunnel_origin')
             origin.setH(-33.33)
         elif zoneId == ToontownGlobals.BossbotLobby:
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: COGHQ: Visit BossbotLobby')
             self.notify.debug('cogHQLobbyModelPath = %s' % self.cogHQLobbyModelPath)
             self.geom = loader.loadModel(self.cogHQLobbyModelPath)

--- a/toontown/coghq/CashbotCogHQLoader.py
+++ b/toontown/coghq/CashbotCogHQLoader.py
@@ -8,7 +8,7 @@ from toontown.toon import Toon
 from direct.fsm import State
 from . import CashbotHQExterior
 from . import CashbotHQBossBattle
-from panda3d.core import DecalEffect
+from panda3d.core import ConfigVariableBool, DecalEffect
 
 class CashbotCogHQLoader(CogHQLoader.CogHQLoader):
     notify = DirectNotifyGlobal.directNotify.newCategory('CashbotCogHQLoader')
@@ -51,7 +51,7 @@ class CashbotCogHQLoader(CogHQLoader.CogHQLoader):
             signText.setPosHpr(locator, 0, 0, 0, 0, 0, 0)
             signText.setDepthWrite(0)
         elif zoneId == ToontownGlobals.CashbotLobby:
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: COGHQ: Visit CashbotLobby')
             self.geom = loader.loadModel(self.cogHQLobbyModelPath)
         else:

--- a/toontown/coghq/DistributedBanquetTable.py
+++ b/toontown/coghq/DistributedBanquetTable.py
@@ -1,6 +1,6 @@
 import math
 import random
-from panda3d.core import NodePath, Point3, VBase4, TextNode, Vec3, deg2Rad, CollisionSegment, CollisionHandlerQueue, CollisionNode, BitMask32
+from panda3d.core import NodePath, Point3, VBase4, TextNode, Vec3, deg2Rad, CollisionSegment, CollisionHandlerQueue, CollisionNode, BitMask32, ConfigVariableDouble
 from panda3d.direct import SmoothMover
 from direct.fsm import FSM
 from direct.distributed import DistributedObject
@@ -30,8 +30,8 @@ class DistributedBanquetTable(DistributedObject.DistributedObject, FSM.FSM, Banq
     pitcherMinH = -360
     pitcherMaxH = 360
     rotateSpeed = 30
-    waterPowerSpeed = base.config.GetDouble('water-power-speed', 15)
-    waterPowerExponent = base.config.GetDouble('water-power-exponent', 0.75)
+    waterPowerSpeed = ConfigVariableDouble('water-power-speed', 15).getValue()
+    waterPowerExponent = ConfigVariableDouble('water-power-exponent', 0.75).getValue()
     useNewAnimations = True
     TugOfWarControls = False
     OnlyUpArrow = True

--- a/toontown/coghq/DistributedCountryClub.py
+++ b/toontown/coghq/DistributedCountryClub.py
@@ -18,7 +18,7 @@ class DistributedCountryClub(DistributedObject.DistributedObject):
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedCountryClub')
     ReadyPost = 'CountryClubReady'
     WinEvent = 'CountryClubWinEvent'
-    doBlockRooms = base.config.GetBool('block-country-club-rooms', 1)
+    doBlockRooms = ConfigVariableBool('block-country-club-rooms', 1).getValue()
 
     def __init__(self, cr):
         DistributedObject.DistributedObject.__init__(self, cr)

--- a/toontown/coghq/DistributedGolfSpot.py
+++ b/toontown/coghq/DistributedGolfSpot.py
@@ -1,5 +1,5 @@
 import math
-from panda3d.core import Point3, CollisionSphere, CollisionNode, CollisionHandlerEvent, TextNode, VBase4, NodePath, BitMask32
+from panda3d.core import Point3, CollisionSphere, CollisionNode, CollisionHandlerEvent, TextNode, VBase4, NodePath, BitMask32, ConfigVariableDouble
 from panda3d.direct import SmoothMover
 from direct.fsm import FSM
 from direct.distributed import DistributedObject
@@ -22,8 +22,8 @@ class DistributedGolfSpot(DistributedObject.DistributedObject, FSM.FSM):
     toonGolfOffsetPos = Point3(-2, 0, -GolfGlobals.GOLF_BALL_RADIUS)
     toonGolfOffsetHpr = Point3(-90, 0, 0)
     rotateSpeed = 20
-    golfPowerSpeed = base.config.GetDouble('golf-power-speed', 3)
-    golfPowerExponent = base.config.GetDouble('golf-power-exponent', 0.75)
+    golfPowerSpeed = ConfigVariableDouble('golf-power-speed', 3).getValue()
+    golfPowerExponent = ConfigVariableDouble('golf-power-exponent', 0.75).getValue()
 
     def __init__(self, cr):
         DistributedObject.DistributedObject.__init__(self, cr)

--- a/toontown/coghq/FactoryLevelMgr.py
+++ b/toontown/coghq/FactoryLevelMgr.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.level import LevelMgr
 from . import FactoryUtil
 from direct.showbase.PythonUtil import Functor
@@ -16,7 +17,7 @@ class FactoryLevelMgr(LevelMgr.LevelMgr):
 
     def __init__(self, level, entId):
         LevelMgr.LevelMgr.__init__(self, level, entId)
-        if base.config.GetBool('want-factory-lifter', 0):
+        if ConfigVariableBool('want-factory-lifter', 0).getValue():
             self.toonLifter = FactoryUtil.ToonLifter('f3')
         self.callSetters('farPlaneDistance')
         self.geom.reparentTo(render)

--- a/toontown/coghq/LawbotCogHQLoader.py
+++ b/toontown/coghq/LawbotCogHQLoader.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from direct.fsm import StateData
 from . import CogHQLoader
@@ -60,7 +61,7 @@ class LawbotCogHQLoader(CogHQLoader.CogHQLoader):
             ug = self.geom.find('**/underground')
             ug.setBin('ground', -10)
         elif zoneId == ToontownGlobals.LawbotLobby:
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: COGHQ: Visit LawbotLobby')
             self.notify.debug('cogHQLobbyModelPath = %s' % self.cogHQLobbyModelPath)
             self.geom = loader.loadModel(self.cogHQLobbyModelPath)

--- a/toontown/coghq/LevelSuitPlannerAI.py
+++ b/toontown/coghq/LevelSuitPlannerAI.py
@@ -14,7 +14,7 @@ class LevelSuitPlannerAI(DirectObject.DirectObject):
         self.level = level
         self.cogCtor = cogCtor
         self.cogSpecs = cogSpecs
-        if simbase.config.GetBool('level-reserve-suits', 0):
+        if ConfigVariableBool('level-reserve-suits', 0).getValue():
             self.reserveCogSpecs = reserveCogSpecs
         else:
             self.reserveCogSpecs = []

--- a/toontown/coghq/SellbotCogHQLoader.py
+++ b/toontown/coghq/SellbotCogHQLoader.py
@@ -10,7 +10,7 @@ from . import FactoryExterior
 from . import FactoryInterior
 from . import SellbotHQExterior
 from . import SellbotHQBossBattle
-from panda3d.core import DecalEffect
+from panda3d.core import ConfigVariableBool, DecalEffect
 aspectSF = 0.7227
 
 class SellbotCogHQLoader(CogHQLoader.CogHQLoader):
@@ -119,7 +119,7 @@ class SellbotCogHQLoader(CogHQLoader.CogHQLoader):
             sdText = DirectGui.OnscreenText(text=TTLocalizer.SellbotSideEntrance, font=ToontownGlobals.getSuitFont(), pos=(0, -0.34), scale=0.1, mayChange=False, parent=sdSign)
             sdText.setDepthWrite(0)
         elif zoneId == ToontownGlobals.SellbotLobby:
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: COGHQ: Visit SellbotLobby')
             self.geom = loader.loadModel(self.cogHQLobbyModelPath)
             front = self.geom.find('**/frontWall')

--- a/toontown/distributed/NonRepeatableRandomSourceUD.py
+++ b/toontown/distributed/NonRepeatableRandomSourceUD.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.DistributedObjectGlobalUD import DistributedObjectGlobalUD
 from direct.directnotify.DirectNotifyGlobal import directNotify
 import random
@@ -20,8 +21,8 @@ class NonRepeatableRandomSourceUD(DistributedObjectGlobalUD):
         self._requests = []
         self._fakeIt = 0
         if __dev__:
-            NonRepeatableRandomSourceUD.RandomNumberCacheSize = config.GetInt('random-source-cache-size', 5000)
-            self._fakeIt = config.GetBool('fake-non-repeatable-random-source', self._fakeIt)
+            NonRepeatableRandomSourceUD.RandomNumberCacheSize = ConfigVariableInt('random-source-cache-size', 5000).getValue()
+            self._fakeIt = ConfigVariableBool('fake-non-repeatable-random-source', self._fakeIt).getValue()
 
     def randomSample(self, nrrsDoId, random):
         self._randoms = [random] + self._randoms

--- a/toontown/distributed/PlayGame.py
+++ b/toontown/distributed/PlayGame.py
@@ -237,7 +237,7 @@ class PlayGame(StateData.StateData):
         loaderName = requestStatus['loader']
         avId = requestStatus.get('avId', -1)
         ownerId = requestStatus.get('ownerId', avId)
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: NEIGHBORHOODS: Visit %s' % hoodName)
         count = ToontownGlobals.hoodCountMap[canonicalHoodId]
         if loaderName == 'safeZoneLoader':
@@ -398,8 +398,8 @@ class PlayGame(StateData.StateData):
         base.localAvatar.chatMgr.obscure(1, 1)
         base.localAvatar.obscureFriendsListButton(1)
         requestStatus['how'] = 'tutorial'
-        if base.config.GetString('language', 'english') == 'japanese':
-            musicVolume = base.config.GetFloat('tutorial-music-volume', 0.5)
+        if ConfigVariableString('language', 'english').getValue() == 'japanese':
+            musicVolume = ConfigVariableDouble('tutorial-music-volume', 0.5).getValue()
             requestStatus['musicVolume'] = musicVolume
         self.hood.enter(requestStatus)
 

--- a/toontown/effects/DistributedFireworkShowAI.py
+++ b/toontown/effects/DistributedFireworkShowAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.distributed import DistributedObjectAI
 from direct.directnotify import DirectNotifyGlobal
@@ -30,7 +31,7 @@ class DistributedFireworkShowAI(DistributedObjectAI.DistributedObjectAI):
         self.timestamp = timestamp
         self.sendUpdate("startShow",
                         (self.eventId, self.style, self.timestamp))
-        if simbase.air.config.GetBool('want-old-fireworks', 0):
+        if ConfigVariableBool('want-old-fireworks', 0).getValue():
             duration = getShowDuration(self.eventId, self.style)
             taskMgr.doMethodLater(duration, self.fireworkShowDone, self.taskName("waitForShowDone"))
         else:

--- a/toontown/effects/FireworkEffect.py
+++ b/toontown/effects/FireworkEffect.py
@@ -85,7 +85,7 @@ class FireworkEffect(NodePath):
             if self.trailTypeId is None:
                 return self.trailEffectsIval
             self.trailEffectsIval.append(Func(random.choice(self.trailSfx).play))
-            if base.config.GetInt('toontown-sfx-setting', 1) == 0:
+            if ConfigVariableInt('toontown-sfx-setting', 1).getValue() == 0:
                 if self.trailTypeId != FireworkTrailType.LongGlowSparkle:
                     self.trailTypeId = FireworkTrailType.Default
             if self.trailTypeId == FireworkTrailType.Default:
@@ -167,7 +167,7 @@ class FireworkEffect(NodePath):
                     trailEffect.setLifespan(3.5)
                     self.trailEffects.append(trailEffect)
                     self.trailEffectsIval.append(Func(trailEffect.startLoop))
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     trailEffect = GlowTrail.getEffect()
                     if trailEffect:
                         trailEffect.reparentTo(self.effectsNode)
@@ -199,7 +199,7 @@ class FireworkEffect(NodePath):
             primaryBlast.fadeTime = 0.75
             self.burstEffectsIval.append(primaryBlast.getTrack())
             self.burstEffects.append(primaryBlast)
-            if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+            if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                 secondaryBlast = BlastEffect()
                 secondaryBlast.reparentTo(self.effectsNode)
                 secondaryBlast.setScale(250 * self.scale)
@@ -225,14 +225,14 @@ class FireworkEffect(NodePath):
                     explosion.startDelay = 0.0
                     self.burstEffectsIval.append(explosion.getTrack())
                     self.burstEffects.append(explosion)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     rays = RayBurst()
                     rays.reparentTo(self.effectsNode)
                     rays.setEffectScale(self.scale)
                     rays.setEffectColor(self.primaryColor)
                     self.burstEffectsIval.append(rays.getTrack())
                     self.burstEffects.append(rays)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 2:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 2:
                     sparkles = FireworkSparkles.getEffect()
                     if sparkles:
                         sparkles.reparentTo(self.effectsNode)
@@ -241,7 +241,7 @@ class FireworkEffect(NodePath):
                         sparkles.startDelay = 0.0
                         self.burstEffectsIval.append(sparkles.getTrack())
                         self.burstEffects.append(sparkles)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     explosion = PeonyEffect.getEffect()
                     if explosion:
                         explosion.reparentTo(self.effectsNode)
@@ -259,7 +259,7 @@ class FireworkEffect(NodePath):
                     explosion.setEffectColor(self.primaryColor)
                     self.burstEffectsIval.append(explosion.getTrack())
                     self.burstEffects.append(explosion)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     rays = RayBurst()
                     rays.reparentTo(self.effectsNode)
                     rays.setEffectScale(self.scale * 0.75)
@@ -274,7 +274,7 @@ class FireworkEffect(NodePath):
                     explosion.setEffectColor(self.primaryColor)
                     self.burstEffectsIval.append(explosion.getTrack())
                     self.burstEffects.append(explosion)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     rays = RayBurst()
                     rays.reparentTo(self.effectsNode)
                     rays.setEffectScale(self.scale)
@@ -296,7 +296,7 @@ class FireworkEffect(NodePath):
                 explosion.setEffectColor(self.primaryColor)
                 self.burstEffectsIval.append(explosion.getTrack())
                 self.burstEffects.append(explosion)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 2:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 2:
                     sparkles = FireworkSparkles.getEffect()
                     if sparkles:
                         sparkles.reparentTo(self.effectsNode)
@@ -352,7 +352,7 @@ class FireworkEffect(NodePath):
                     explosion.setEffectColor(self.primaryColor)
                     self.burstEffectsIval.append(Sequence(Wait(0.1), explosion.getTrack()))
                     self.burstEffects.append(explosion)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     rays = RayBurst()
                     rays.reparentTo(self.effectsNode)
                     rays.setEffectScale(self.scale)
@@ -376,14 +376,14 @@ class FireworkEffect(NodePath):
                     skullFlash.startDelay = 0.08
                     self.burstEffectsIval.append(skullFlash.getTrack())
                     self.burstEffects.append(skullFlash)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 1:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 1:
                     rays = RayBurst()
                     rays.reparentTo(self.effectsNode)
                     rays.setEffectScale(self.scale)
                     rays.setEffectColor(self.primaryColor)
                     self.burstEffectsIval.append(rays.getTrack())
                     self.burstEffects.append(rays)
-                if base.config.GetInt('toontown-sfx-setting', 1) >= 2:
+                if ConfigVariableInt('toontown-sfx-setting', 1).getValue() >= 2:
                     sparkles = FireworkSparkles.getEffect()
                     if sparkles:
                         sparkles.reparentTo(self.effectsNode)
@@ -399,7 +399,7 @@ class FireworkEffect(NodePath):
                     explosion.reparentTo(self.effectsNode)
                     explosion.setEffectScale(self.scale)
                     explosion.setEffectColor(self.primaryColor)
-                    explosion.numTrails = 3 + base.config.GetInt('toontown-sfx-setting', 1)
+                    explosion.numTrails = 3 + ConfigVariableInt('toontown-sfx-setting', 1).getValue()
                     self.burstEffectsIval.append(explosion.getTrack())
                     self.burstEffects.append(explosion)
             elif self.burstTypeId == FireworkBurstType.IceCream:

--- a/toontown/effects/FireworkShowMixin.py
+++ b/toontown/effects/FireworkShowMixin.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from direct.distributed.ClockDelta import *
 from direct.interval.IntervalGlobal import *
@@ -26,7 +27,7 @@ class FireworkShowMixin:
         if self.currentShow:
             self.currentShow.pause()
             self.currentShow = None
-            if base.cr.config.GetBool('want-old-fireworks', 0):
+            if ConfigVariableBool('want-old-fireworks', 0).getValue():
                 ivalMgr.finishIntervalsMatching('shootFirework*')
             else:
                 self.destroyFireworkShow()
@@ -60,7 +61,7 @@ class FireworkShowMixin:
         self.timestamp = timestamp
         self.showMusic = None
         self.eventId = eventId
-        if base.config.GetBool('want-old-fireworks', 0):
+        if ConfigVariableBool('want-old-fireworks', 0).getValue():
             self.currentShow = self.getFireworkShowIval(eventId, style, t)
             if self.currentShow:
                 self.currentShow.start(t)

--- a/toontown/estate/DistributedHouse.py
+++ b/toontown/estate/DistributedHouse.py
@@ -75,10 +75,10 @@ class DistributedHouse(DistributedObject.DistributedObject):
         self.notify.debug('load')
         if not self.house_loaded:
             if self.housePosInd == 1:
-                houseModelIndex = base.config.GetInt('want-custom-house', HouseGlobals.HOUSE_DEFAULT)
+                houseModelIndex = ConfigVariableInt('want-custom-house', HouseGlobals.HOUSE_DEFAULT).getValue()
             else:
                 houseModelIndex = HouseGlobals.HOUSE_DEFAULT
-            houseModelIndex = base.config.GetInt('want-custom-house-all', houseModelIndex)
+            houseModelIndex = ConfigVariableInt('want-custom-house-all', houseModelIndex).getValue()
             houseModel = self.cr.playGame.hood.loader.houseModels[houseModelIndex]
             self.house = houseModel.copyTo(self.cr.playGame.hood.loader.houseNode[self.housePosInd])
             self.house_loaded = 1

--- a/toontown/estate/Estate.py
+++ b/toontown/estate/Estate.py
@@ -106,7 +106,7 @@ class Estate(Place.Place):
         hoodId = requestStatus['hoodId']
         zoneId = requestStatus['zoneId']
         newsManager = base.cr.newsManager
-        if config.GetBool('want-estate-telemetry-limiter', 1):
+        if ConfigVariableBool('want-estate-telemetry-limiter', 1).getValue():
             limiter = TLGatherAllAvs('Estate', RotationLimitToH)
         else:
             limiter = TLNull()
@@ -355,7 +355,7 @@ class Estate(Place.Place):
         self.notify.debug('continuing in __submergeToon')
         if hasattr(self, 'loader') and self.loader:
             base.playSfx(self.loader.submergeSound)
-        if base.config.GetBool('disable-flying-glitch') == 0:
+        if ConfigVariableBool('disable-flying-glitch').getValue() == 0:
             self.fsm.request('walk')
         self.walkStateData.fsm.request('swimming', [self.loader.swimSound])
         pos = base.localAvatar.getPos(render)

--- a/toontown/estate/houseDesign.py
+++ b/toontown/estate/houseDesign.py
@@ -1151,7 +1151,7 @@ class ObjectManager(NodePath, DirectObject):
         return
 
     def sendItemToAttic(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ESTATE:  Send Item to Attic')
         messenger.send('wakeup')
         if self.selectedObject:
@@ -1253,7 +1253,7 @@ class ObjectManager(NodePath, DirectObject):
         return
 
     def bringItemFromAttic(self, item, itemIndex):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ESTATE: Place Item in Room')
         messenger.send('wakeup')
         self.__enableItemButtons(0)
@@ -1471,7 +1471,7 @@ class ObjectManager(NodePath, DirectObject):
         return
 
     def __handleVerifyDeleteOK(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ESTATE:  Send Item to Trash')
         deleteFunction = self.verifyItems[0]
         deleteFunctionArgs = self.verifyItems[1:]
@@ -1582,7 +1582,7 @@ class ObjectManager(NodePath, DirectObject):
         self.verifyItems = (item, itemIndex)
 
     def __handleVerifyReturnFromTrashOK(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ESTATE:  Send Item to Attic')
         item, itemIndex = self.verifyItems
         self.__cleanupVerifyDelete()

--- a/toontown/fishing/FishBase.py
+++ b/toontown/fishing/FishBase.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from . import FishGlobals
 from toontown.toonbase import TTLocalizer
 from direct.directnotify import DirectNotifyGlobal
@@ -56,7 +57,7 @@ class FishBase:
         loop = None
         delay = None
         playRate = None
-        if base.config.GetBool('want-fish-audio', 1):
+        if ConfigVariableBool('want-fish-audio', 1).getValue():
             soundDict = FishGlobals.FishAudioFileDict
             fileInfo = soundDict.get(self.genus, None)
             if fileInfo:

--- a/toontown/friends/FriendInviter.py
+++ b/toontown/friends/FriendInviter.py
@@ -2,7 +2,6 @@ from panda3d.core import *
 from direct.task.Task import Task
 from toontown.toonbase.ToontownGlobals import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.showbase import DirectObject
 from direct.fsm import ClassicFSM, State
 from direct.fsm import State
@@ -45,7 +44,7 @@ class FriendInviter(DirectFrame):
     notify = DirectNotifyGlobal.directNotify.newCategory('FriendInviter')
 
     def __init__(self, avId, avName, avDisableName):
-        self.wantPlayerFriends = base.config.GetBool('want-player-friends', 0)
+        self.wantPlayerFriends = ConfigVariableBool('want-player-friends', 0).getValue()
         DirectFrame.__init__(self, pos=(0.3, 0.1, 0.65), image_color=GlobalDialogColor, image_scale=(1.0, 1.0, 0.6), text='', text_wordwrap=TTLocalizer.FIdirectFrameWordwrap, text_scale=TTLocalizer.FIdirectFrame, text_pos=TTLocalizer.FIdirectFramePos)
         self['image'] = DGG.getDefaultDialogGeom()
         self.avId = avId
@@ -455,7 +454,7 @@ class FriendInviter(DirectFrame):
         pass
 
     def __handleOk(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: MAKEAFRIENDSHIP: Make a friendship')
         unloadFriendInviter()
 
@@ -466,7 +465,7 @@ class FriendInviter(DirectFrame):
         unloadFriendInviter()
 
     def __handleStop(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: BREAKAFRIENDSHIP: Break a friendship')
         self.fsm.request('endFriendship')
 

--- a/toontown/golf/DistributedGolfCourseAI.py
+++ b/toontown/golf/DistributedGolfCourseAI.py
@@ -561,7 +561,7 @@ class DistributedGolfCourseAI(DistributedObjectAI.DistributedObjectAI, FSM):
 
     def calcHolesToUse(self):
         retval = []
-        if simbase.air.config.GetBool('golf-course-randomized', 1):
+        if ConfigVariableBool('golf-course-randomized', 1).getValue():
             retval = self.calcHolesToUseRandomized(self.courseId)
             self.notify.debug('randomized courses!')
             for x in range(len(retval)):

--- a/toontown/golf/DistributedGolfHole.py
+++ b/toontown/golf/DistributedGolfHole.py
@@ -1,7 +1,7 @@
 import math
 import random
 import time
-from panda3d.core import TextNode, BitMask32, Point3, Vec3, Vec4, deg2Rad, Mat3, NodePath, VBase4, CollisionTraverser, CollisionSegment, CollisionNode, CollisionHandlerQueue
+from panda3d.core import TextNode, BitMask32, Point3, Vec3, Vec4, deg2Rad, Mat3, NodePath, VBase4, CollisionTraverser, CollisionSegment, CollisionNode, CollisionHandlerQueue, ConfigVariableBool, ConfigVariableDouble
 from panda3d.ode import OdeRayGeom
 from direct.distributed import DistributedObject
 from direct.directnotify import DirectNotifyGlobal
@@ -57,10 +57,10 @@ class DistributedGolfHole(DistributedPhysicsWorld.DistributedPhysicsWorld, FSM, 
      'Cleanup': ['Off']}
     id = 0
     notify = directNotify.newCategory('DistributedGolfHole')
-    unlimitedAimTime = base.config.GetBool('unlimited-aim-time', 0)
-    unlimitedTeeTime = base.config.GetBool('unlimited-tee-time', 0)
-    golfPowerSpeed = base.config.GetDouble('golf-power-speed', 3)
-    golfPowerExponent = base.config.GetDouble('golf-power-exponent', 0.75)
+    unlimitedAimTime = ConfigVariableBool('unlimited-aim-time', 0).getValue()
+    unlimitedTeeTime = ConfigVariableBool('unlimited-tee-time', 0).getValue()
+    golfPowerSpeed = ConfigVariableDouble('golf-power-speed', 3).getValue()
+    golfPowerExponent = ConfigVariableDouble('golf-power-exponent', 0.75).getValue()
     DefaultCamP = -16
     MaxCamP = -90
 
@@ -289,7 +289,7 @@ class DistributedGolfHole(DistributedPhysicsWorld.DistributedPhysicsWorld, FSM, 
             curNodePath = self.hardSurfaceNodePath.find('**/locator%d' % locatorNum)
 
     def loadBlockers(self):
-        loadAll = base.config.GetBool('golf-all-blockers', 0)
+        loadAll = ConfigVariableBool('golf-all-blockers', 0).getValue()
         self.createLocatorDict()
         self.blockerNums = self.holeInfo['blockers']
         for locatorNum in self.locDict:

--- a/toontown/golf/DistributedGolfHoleAI.py
+++ b/toontown/golf/DistributedGolfHoleAI.py
@@ -196,7 +196,7 @@ class DistributedGolfHoleAI(DistributedPhysicsWorldAI.DistributedPhysicsWorldAI,
             curNodePath = self.hardSurfaceNodePath.find('**/locator%d' % locatorNum)
 
     def loadBlockers(self):
-        loadAll = simbase.config.GetBool('golf-all-blockers', 0)
+        loadAll = ConfigVariableBool('golf-all-blockers', 0).getValue()
         self.createLocatorDict()
         self.blockerNums = self.holeInfo['blockers']
         for locatorNum in self.locDict:
@@ -240,7 +240,7 @@ class DistributedGolfHoleAI(DistributedPhysicsWorldAI.DistributedPhysicsWorldAI,
     def choosePlayerToSimulate(self):
         stillPlaying = self.golfCourse.getStillPlayingAvIds()
         playerId = 0
-        if simbase.air.config.GetBool('golf-trust-driver-first', 0):
+        if ConfigVariableBool('golf-trust-driver-first', 0).getValue():
             if stillPlaying:
                 playerId = stillPlaying[0]
         else:

--- a/toontown/hood/BossbotHQDataAI.py
+++ b/toontown/hood/BossbotHQDataAI.py
@@ -1,4 +1,4 @@
-from panda3d.core import Point3
+from panda3d.core import ConfigVariableBool, Point3
 from direct.directnotify import DirectNotifyGlobal
 from . import HoodDataAI
 from toontown.toonbase import ToontownGlobals
@@ -40,7 +40,7 @@ class BossbotHQDataAI(HoodDataAI.HoodDataAI):
         self.lobbyElevator = DistributedBBElevatorAI.DistributedBBElevatorAI(self.air, self.lobbyMgr, ToontownGlobals.BossbotLobby, antiShuffle=1)
         self.lobbyElevator.generateWithRequired(ToontownGlobals.BossbotLobby)
         self.addDistObj(self.lobbyElevator)
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.boardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, [self.lobbyElevator.doId], 8)
             self.boardingParty.generateWithRequired(ToontownGlobals.BossbotLobby)
 
@@ -59,7 +59,7 @@ class BossbotHQDataAI(HoodDataAI.HoodDataAI):
 
         makeDoor(ToontownGlobals.BossbotLobby, 0, 0, FADoorCodes.BB_DISGUISE_INCOMPLETE)
         kartIdList = self.createCogKarts()
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.courseBoardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, kartIdList, 4)
             self.courseBoardingParty.generateWithRequired(self.zoneId)
 

--- a/toontown/hood/CSHoodDataAI.py
+++ b/toontown/hood/CSHoodDataAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from . import HoodDataAI
 from toontown.toonbase import ToontownGlobals
@@ -35,11 +36,11 @@ class CSHoodDataAI(HoodDataAI.HoodDataAI):
         self.lobbyElevator = DistributedVPElevatorAI.DistributedVPElevatorAI(self.air, self.lobbyMgr, ToontownGlobals.SellbotLobby, antiShuffle=1)
         self.lobbyElevator.generateWithRequired(ToontownGlobals.SellbotLobby)
         self.addDistObj(self.lobbyElevator)
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.boardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, [self.lobbyElevator.doId], 8)
             self.boardingParty.generateWithRequired(ToontownGlobals.SellbotLobby)
         factoryIdList = [self.testElev0.doId, self.testElev1.doId]
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.factoryBoardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, factoryIdList, 4)
             self.factoryBoardingParty.generateWithRequired(ToontownGlobals.SellbotFactoryExt)
         destinationZone = ToontownGlobals.SellbotLobby

--- a/toontown/hood/CashbotHQDataAI.py
+++ b/toontown/hood/CashbotHQDataAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from . import HoodDataAI
 from toontown.toonbase import ToontownGlobals
@@ -38,7 +39,7 @@ class CashbotHQDataAI(HoodDataAI.HoodDataAI):
         self.lobbyElevator = DistributedCFOElevatorAI.DistributedCFOElevatorAI(self.air, self.lobbyMgr, ToontownGlobals.CashbotLobby, antiShuffle=1)
         self.lobbyElevator.generateWithRequired(ToontownGlobals.CashbotLobby)
         self.addDistObj(self.lobbyElevator)
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.boardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, [self.lobbyElevator.doId], 8)
             self.boardingParty.generateWithRequired(ToontownGlobals.CashbotLobby)
         destinationZone = ToontownGlobals.CashbotLobby
@@ -50,7 +51,7 @@ class CashbotHQDataAI(HoodDataAI.HoodDataAI):
         intDoor0.zoneId = ToontownGlobals.CashbotLobby
         mintIdList = [
          self.testElev0.doId, self.testElev1.doId, self.testElev2.doId]
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.mintBoardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, mintIdList, 4)
             self.mintBoardingParty.generateWithRequired(self.zoneId)
         for extDoor in extDoorList:

--- a/toontown/hood/GenericAnimatedBuilding.py
+++ b/toontown/hood/GenericAnimatedBuilding.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from toontown.hood import GenericAnimatedProp
 
 class GenericAnimatedBuilding(GenericAnimatedProp.GenericAnimatedProp):
@@ -6,5 +7,5 @@ class GenericAnimatedBuilding(GenericAnimatedProp.GenericAnimatedProp):
         GenericAnimatedProp.GenericAnimatedProp.__init__(self, node)
 
     def enter(self):
-        if base.config.GetBool('buildings-animate', False):
+        if ConfigVariableBool('buildings-animate', False).getValue():
             GenericAnimatedProp.GenericAnimatedProp.enter(self)

--- a/toontown/hood/GenericAnimatedProp.py
+++ b/toontown/hood/GenericAnimatedProp.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from . import AnimatedProp
 from direct.actor import Actor
 from direct.interval.IntervalGlobal import *
@@ -112,7 +113,7 @@ class GenericAnimatedProp(AnimatedProp.AnimatedProp):
         if theSound:
             soundDur = theSound.length()
             if maximumDuration < soundDur:
-                if base.config.GetBool('interactive-prop-info', False):
+                if ConfigVariableBool('interactive-prop-info', False).getValue():
                     if self.visId == localAvatar.zoneId and origAnimName != 'tt_a_ara_dga_hydrant_idleIntoFight':
                         self.notify.warning('anim %s had duration of %s while sound  has duration of %s' % (origAnimName, maximumDuration, soundDur))
                 soundDur = maximumDuration

--- a/toontown/hood/HydrantInteractiveProp.py
+++ b/toontown/hood/HydrantInteractiveProp.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from direct.actor import Actor
 from direct.directnotify import DirectNotifyGlobal
 from direct.interval.IntervalGlobal import Sequence, Func
@@ -176,7 +177,7 @@ class HydrantInteractiveProp(InteractiveAnimatedProp.InteractiveAnimatedProp):
      ToontownGlobals.MinniesMelodyland: ('tt_a_ara_mml_hydrant_fightBoost', 'tt_a_ara_mml_hydrant_fightCheer', 'tt_a_ara_mml_hydrant_fightIdle'),
      ToontownGlobals.TheBrrrgh: ('tt_a_ara_tbr_hydrant_fightBoost', 'tt_a_ara_tbr_hydrant_fightCheer', 'tt_a_ara_tbr_hydrant_fightIdle'),
      ToontownGlobals.DonaldsDreamland: ('tt_a_ara_ddl_hydrant_fightBoost', 'tt_a_ara_ddl_hydrant_fightCheer', 'tt_a_ara_ddl_hydrant_fightIdle')}
-    IdlePauseTime = base.config.GetFloat('prop-idle-pause-time', 0.0)
+    IdlePauseTime = ConfigVariableDouble('prop-idle-pause-time', 0.0).getValue()
 
     def __init__(self, node):
         self.leftWater = None

--- a/toontown/hood/HydrantOneAnimatedProp.py
+++ b/toontown/hood/HydrantOneAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class HydrantOneAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('HydrantOneAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_ttc_hydrant_firstMoveArmUp1', 40 * PauseTimeMult),
      1: ('tt_a_ara_ttc_hydrant_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_ttc_hydrant_firstMoveArmUp2', 10 * PauseTimeMult),

--- a/toontown/hood/HydrantTwoAnimatedProp.py
+++ b/toontown/hood/HydrantTwoAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class HydrantTwoAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('HydrantTwoAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_ttc_hydrant_firstMoveArmUp1', 40 * PauseTimeMult),
      1: ('tt_a_ara_ttc_hydrant_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_ttc_hydrant_firstMoveArmUp2', 10 * PauseTimeMult),

--- a/toontown/hood/HydrantZeroAnimatedProp.py
+++ b/toontown/hood/HydrantZeroAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class HydrantZeroAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('HydrantZeroAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_ttc_hydrant_firstMoveArmUp1', 40 * PauseTimeMult),
      1: ('tt_a_ara_ttc_hydrant_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_ttc_hydrant_firstMoveArmUp2', 10 * PauseTimeMult),

--- a/toontown/hood/InteractiveAnimatedProp.py
+++ b/toontown/hood/InteractiveAnimatedProp.py
@@ -5,7 +5,7 @@ from direct.actor import Actor
 from direct.interval.IntervalGlobal import Sequence, ActorInterval, Wait, Func, SoundInterval, Parallel
 from direct.fsm import FSM
 from direct.showbase.PythonUtil import weightedChoice
-from panda3d.core import TextNode, Vec3
+from panda3d.core import ConfigVariableBool, ConfigVariableDouble, TextNode, Vec3
 from toontown.toonbase import ToontownGlobals
 from toontown.hood import ZoneUtil
 
@@ -26,7 +26,7 @@ class InteractiveAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
     ZoneToFightAnims = {}
     ZoneToVictoryAnims = {}
     ZoneToSadAnims = {}
-    IdlePauseTime = base.config.GetFloat('prop-idle-pause-time', 0.0)
+    IdlePauseTime = ConfigVariableDouble('prop-idle-pause-time', 0.0).getValue()
     HpTextGenerator = TextNode('HpTextGenerator')
     BattleCheerText = '+'
 
@@ -200,13 +200,13 @@ class InteractiveAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
 
     def enter(self):
         GenericAnimatedProp.GenericAnimatedProp.enter(self)
-        if base.config.GetBool('props-buff-battles', True):
+        if ConfigVariableBool('props-buff-battles', True).getValue():
             self.notify.debug('props buff battles is true')
             if base.cr.newsManager.isHolidayRunning(self.holidayId):
                 self.notify.debug('holiday is running, doing idle interval')
                 self.node.stop()
                 self.node.pose('idle0', 0)
-                if base.config.GetBool('interactive-prop-random-idles', 1):
+                if ConfigVariableBool('interactive-prop-random-idles', 1).getValue():
                     self.requestIdleOrSad()
                 else:
                     self.idleInterval.loop()
@@ -262,7 +262,7 @@ class InteractiveAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
 
     def chooseIdleAnimToRun(self):
         result = self.numIdles - 1
-        if base.config.GetBool('randomize-interactive-idles', True):
+        if ConfigVariableBool('randomize-interactive-idles', True).getValue():
             pairs = []
             for i in range(self.numIdles):
                 reversedChance = self.numIdles - i - 1
@@ -482,16 +482,16 @@ class InteractiveAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
         if self.hasSpecialIval(origAnimName):
             specialIval = self.getSpecialIval(origAnimName)
             idleAnimAndSound = Parallel(animIval, soundIval, specialIval)
-            if base.config.GetBool('interactive-prop-info', False):
+            if ConfigVariableBool('interactive-prop-info', False).getValue():
                 idleAnimAndSound.append(printFunc)
         else:
             idleAnimAndSound = Parallel(animIval, soundIval)
-            if base.config.GetBool('interactive-prop-info', False):
+            if ConfigVariableBool('interactive-prop-info', False).getValue():
                 idleAnimAndSound.append(printFunc)
         return idleAnimAndSound
 
     def printAnimIfClose(self, animKey):
-        if base.config.GetBool('interactive-prop-info', False):
+        if ConfigVariableBool('interactive-prop-info', False).getValue():
             try:
                 animName = self.node.getAnimFilename(animKey)
                 baseAnimName = animName.split('/')[-1]

--- a/toontown/hood/LawbotHQDataAI.py
+++ b/toontown/hood/LawbotHQDataAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from . import HoodDataAI
 from toontown.toonbase import ToontownGlobals
@@ -44,7 +45,7 @@ class LawbotHQDataAI(HoodDataAI.HoodDataAI):
         self.lobbyElevator = DistributedCJElevatorAI.DistributedCJElevatorAI(self.air, self.lobbyMgr, ToontownGlobals.LawbotLobby, antiShuffle=1)
         self.lobbyElevator.generateWithRequired(ToontownGlobals.LawbotLobby)
         self.addDistObj(self.lobbyElevator)
-        if simbase.config.GetBool('want-boarding-groups', 1):
+        if ConfigVariableBool('want-boarding-groups', 1).getValue():
             self.boardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, [self.lobbyElevator.doId], 8)
             self.boardingParty.generateWithRequired(ToontownGlobals.LawbotLobby)
 
@@ -65,6 +66,6 @@ class LawbotHQDataAI(HoodDataAI.HoodDataAI):
         makeDoor(ToontownGlobals.LawbotOfficeExt, 0, 0)
         officeIdList = [
          officeId0, officeId1, officeId2, officeId3]
-        if simbase.config.GetBool('want-boarding-parties', 1):
+        if ConfigVariableBool('want-boarding-parties', 1).getValue():
             self.officeBoardingParty = DistributedBoardingPartyAI.DistributedBoardingPartyAI(self.air, officeIdList, 4)
             self.officeBoardingParty.generateWithRequired(ToontownGlobals.LawbotOfficeExt)

--- a/toontown/hood/MailboxInteractiveProp.py
+++ b/toontown/hood/MailboxInteractiveProp.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from direct.actor import Actor
 from direct.directnotify import DirectNotifyGlobal
 from direct.interval.IntervalGlobal import Sequence, Func
@@ -176,7 +177,7 @@ class MailboxInteractiveProp(InteractiveAnimatedProp.InteractiveAnimatedProp):
      ToontownGlobals.MinniesMelodyland: ('tt_a_ara_mml_mailbox_fightBoost', 'tt_a_ara_mml_mailbox_fightCheer', 'tt_a_ara_mml_mailbox_fightIdle'),
      ToontownGlobals.TheBrrrgh: ('tt_a_ara_tbr_mailbox_fightBoost', 'tt_a_ara_tbr_mailbox_fightCheer', 'tt_a_ara_tbr_mailbox_fightIdle'),
      ToontownGlobals.DonaldsDreamland: ('tt_a_ara_ddl_mailbox_fightBoost', 'tt_a_ara_ddl_mailbox_fightCheer', 'tt_a_ara_ddl_mailbox_fightIdle')}
-    IdlePauseTime = base.config.GetFloat('prop-idle-pause-time', 0.0)
+    IdlePauseTime = ConfigVariableDouble('prop-idle-pause-time', 0.0).getValue()
 
     def __init__(self, node):
         InteractiveAnimatedProp.InteractiveAnimatedProp.__init__(self, node, ToontownGlobals.MAILBOXES_BUFF_BATTLES)

--- a/toontown/hood/MailboxOneAnimatedProp.py
+++ b/toontown/hood/MailboxOneAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class MailboxOneAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('MailboxOneAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin1', 40 * PauseTimeMult),
      1: (('tt_a_ara_dod_mailbox_firstMoveStruggle', 'tt_a_ara_dod_mailbox_firstMoveJump'), 20 * PauseTimeMult),
      2: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin2', 10 * PauseTimeMult),

--- a/toontown/hood/MailboxTwoAnimatedProp.py
+++ b/toontown/hood/MailboxTwoAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class MailboxTwoAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('MailboxTwoAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin1', 40 * PauseTimeMult),
      1: (('tt_a_ara_dod_mailbox_firstMoveStruggle', 'tt_a_ara_dod_mailbox_firstMoveJump'), 20 * PauseTimeMult),
      2: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin2', 10 * PauseTimeMult),

--- a/toontown/hood/MailboxZeroAnimatedProp.py
+++ b/toontown/hood/MailboxZeroAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class MailboxZeroAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('MailboxZeroAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin1', 40 * PauseTimeMult),
      1: (('tt_a_ara_dod_mailbox_firstMoveStruggle', 'tt_a_ara_dod_mailbox_firstMoveJump'), 20 * PauseTimeMult),
      2: ('tt_a_ara_dod_mailbox_firstMoveFlagSpin2', 10 * PauseTimeMult),

--- a/toontown/hood/OZHoodDataAI.py
+++ b/toontown/hood/OZHoodDataAI.py
@@ -30,7 +30,7 @@ class OZHoodDataAI(HoodDataAI.HoodDataAI):
 
     def startup(self):
         HoodDataAI.HoodDataAI.startup(self)
-        if simbase.air.config.GetBool('create-chip-and-dale', 1):
+        if ConfigVariableBool('create-chip-and-dale', 1).getValue():
             chip = DistributedChipAI.DistributedChipAI(self.air)
             chip.generateWithRequired(self.zoneId)
             chip.start()
@@ -47,7 +47,7 @@ class OZHoodDataAI(HoodDataAI.HoodDataAI):
         self.timer = DistributedTimerAI.DistributedTimerAI(self.air)
         self.timer.generateWithRequired(self.zoneId)
         self.createPicnicTables()
-        if simbase.config.GetBool('want-game-tables', 0):
+        if ConfigVariableBool('want-game-tables', 0).getValue():
             self.createGameTables()
 
     def cleanup(self):

--- a/toontown/hood/Place.py
+++ b/toontown/hood/Place.py
@@ -1,4 +1,4 @@
-from panda3d.core import NodePath
+from panda3d.core import ConfigVariableBool, NodePath
 from panda3d.otp import NametagGlobals
 
 from direct.directnotify.DirectNotifyGlobal import directNotify
@@ -155,7 +155,7 @@ class Place(StateData, FriendsListManager):
         return 1
 
     def handleTeleportQuery(self, fromAvatar, toAvatar):
-        if base.config.GetBool('want-tptrack', False):
+        if ConfigVariableBool('want-tptrack', False).getValue():
             if toAvatar == base.localAvatar:
                 toAvatar.doTeleportResponse(fromAvatar, toAvatar, toAvatar.doId, 1, toAvatar.defaultShard, base.cr.playGame.getPlaceId(), self.getZoneId(), fromAvatar.doId)
             else:

--- a/toontown/hood/StreetSign.py
+++ b/toontown/hood/StreetSign.py
@@ -5,9 +5,9 @@ from direct.distributed import DistributedObject
 
 class StreetSign(DistributedObject.DistributedObject):
     RedownloadTaskName = 'RedownloadStreetSign'
-    StreetSignFileName = config.GetString('street-sign-filename', 'texture.png')
-    StreetSignBaseDir = config.GetString('street-sign-base-dir', 'sign')
-    StreetSignUrl = base.config.GetString('street-sign-url', 'http://cdn.toontown.disney.go.com/toontown/en/street-signs/img/')
+    StreetSignFileName = ConfigVariableString('street-sign-filename', 'texture.png').getValue()
+    StreetSignBaseDir = ConfigVariableString('street-sign-base-dir', 'sign').getValue()
+    StreetSignUrl = ConfigVariableString('street-sign-url', 'http://cdn.toontown.disney.go.com/toontown/en/street-signs/img/').getValue()
     notify = DirectNotifyGlobal.directNotify.newCategory('StreetSign')
 
     def __init__(self):

--- a/toontown/hood/TrashcanInteractiveProp.py
+++ b/toontown/hood/TrashcanInteractiveProp.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from direct.actor import Actor
 from direct.directnotify import DirectNotifyGlobal
 from toontown.hood import InteractiveAnimatedProp
@@ -178,7 +179,7 @@ class TrashcanInteractiveProp(InteractiveAnimatedProp.InteractiveAnimatedProp):
                                          'tt_a_ara_mml_trashcan_fightIdle'),
      ToontownGlobals.TheBrrrgh: ('tt_a_ara_tbr_trashcan_fightBoost', 'tt_a_ara_tbr_trashcan_fightCheer', 'tt_a_ara_tbr_trashcan_fightIdle'),
      ToontownGlobals.DonaldsDreamland: ('tt_a_ara_ddl_trashcan_fightBoost', 'tt_a_ara_ddl_trashcan_fightCheer', 'tt_a_ara_ddl_trashcan_fightIdle')}
-    IdlePauseTime = base.config.GetFloat('prop-idle-pause-time', 0.0)
+    IdlePauseTime = ConfigVariableDouble('prop-idle-pause-time', 0.0).getValue()
 
     def __init__(self, node):
         InteractiveAnimatedProp.InteractiveAnimatedProp.__init__(self, node, ToontownGlobals.TRASHCANS_BUFF_BATTLES)

--- a/toontown/hood/TrashcanOneAnimatedProp.py
+++ b/toontown/hood/TrashcanOneAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class TrashcanOneAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('TrashcanOneAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dga_trashcan_firstMoveLidFlip1', 40 * PauseTimeMult),
      1: ('tt_a_ara_dga_trashcan_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_dga_trashcan_firstMoveLidFlip2', 10 * PauseTimeMult),

--- a/toontown/hood/TrashcanTwoAnimatedProp.py
+++ b/toontown/hood/TrashcanTwoAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class TrashcanTwoAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('TrashcanTwoAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dga_trashcan_firstMoveLidFlip1', 40 * PauseTimeMult),
      1: ('tt_a_ara_dga_trashcan_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_dga_trashcan_firstMoveLidFlip2', 10 * PauseTimeMult),

--- a/toontown/hood/TrashcanZeroAnimatedProp.py
+++ b/toontown/hood/TrashcanZeroAnimatedProp.py
@@ -1,10 +1,11 @@
+from panda3d.core import ConfigVariableDouble
 from toontown.hood import ZeroAnimatedProp
 from toontown.toonbase import ToontownGlobals
 from direct.directnotify import DirectNotifyGlobal
 
 class TrashcanZeroAnimatedProp(ZeroAnimatedProp.ZeroAnimatedProp):
     notify = DirectNotifyGlobal.directNotify.newCategory('TrashcanZeroAnimatedProp')
-    PauseTimeMult = base.config.GetFloat('zero-pause-mult', 1.0)
+    PauseTimeMult = ConfigVariableDouble('zero-pause-mult', 1.0).getValue()
     PhaseInfo = {0: ('tt_a_ara_dga_trashcan_firstMoveLidFlip1', 40 * PauseTimeMult),
      1: ('tt_a_ara_dga_trashcan_firstMoveStruggle', 20 * PauseTimeMult),
      2: ('tt_a_ara_dga_trashcan_firstMoveLidFlip2', 10 * PauseTimeMult),

--- a/toontown/hood/ZeroAnimatedProp.py
+++ b/toontown/hood/ZeroAnimatedProp.py
@@ -1,5 +1,6 @@
 import types
 import math
+from panda3d.core import ConfigVariableBool
 from direct.interval.IntervalGlobal import Sequence, Wait, ActorInterval, Func, SoundInterval, Parallel
 from direct.task import Task
 from direct.fsm import FSM
@@ -95,7 +96,7 @@ class ZeroAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
 
     def chooseAnimToRun(self):
         result = self.curPhase
-        if base.config.GetBool('anim-props-randomized', True):
+        if ConfigVariableBool('anim-props-randomized', True).getValue():
             pairs = []
             for i in range(self.curPhase + 1):
                 pairs.append((math.pow(2, i), i))

--- a/toontown/launcher/ToontownLauncher.py
+++ b/toontown/launcher/ToontownLauncher.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+from panda3d.core import ConfigVariableString
 
 ltime = 1 and time.localtime()
 logSuffix = '%02d%02d%02d_%02d%02d%02d' % (ltime[0] - 2000,  ltime[1], ltime[2],
@@ -89,7 +90,7 @@ class ToontownLauncher(LauncherBase):
         return 'toontown'
 
     def parseWebAcctParams(self):
-        s = config.GetString('fake-web-acct-params', '')
+        s = ConfigVariableString('fake-web-acct-params', '').getValue()
         if not s:
             s = self.getRegistry(self.webAcctParams)
         self.setRegistry(self.webAcctParams, '')

--- a/toontown/login/AvatarChoice.py
+++ b/toontown/login/AvatarChoice.py
@@ -245,7 +245,7 @@ class AvatarChoice(DirectButton):
             self.deleteWithPasswordFrame.hide()
             base.transitions.noTransitions()
             messenger.send(self.doneEvent, ['delete', self.position])
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: DELETEATOON: Deleting A Toon')
         else:
             if errorMsg is not None:
@@ -264,7 +264,7 @@ class AvatarChoice(DirectButton):
             self.deleteWithPasswordFrame.hide()
             base.transitions.noTransitions()
             messenger.send(self.doneEvent, ['delete', self.position])
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: DELETEATOON: Deleting A Toon')
         else:
             self.deleteWithPasswordFrame['text'] = TTLocalizer.AvatarChoiceDeleteWrongConfirm % {'name': self.name,

--- a/toontown/login/AvatarChooser.py
+++ b/toontown/login/AvatarChooser.py
@@ -56,7 +56,7 @@ class AvatarChooser(StateData.StateData):
         if base.cr.loginInterface.supportsRelogin():
             self.logoutButton.show()
         self.pickAToonBG.reparentTo(base.camera)
-        choice = base.config.GetInt('auto-avatar-choice', -1)
+        choice = ConfigVariableInt('auto-avatar-choice', -1).getValue()
         for panel in self.panelList:
             panel.show()
             self.accept(panel.doneEvent, self.__handlePanelDone)

--- a/toontown/makeatoon/MakeAToon.py
+++ b/toontown/makeatoon/MakeAToon.py
@@ -91,7 +91,7 @@ class MakeAToon(StateData.StateData):
 
     def enter(self):
         self.notify.debug('Starting Make A Toon.')
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: MAKEATOON: Starting Make A Toon')
         base.cr.centralLogger.writeClientEvent('MAT - startingMakeAToon')
         base.camLens.setFov(ToontownGlobals.MakeAToonCameraFov)
@@ -252,8 +252,8 @@ class MakeAToon(StateData.StateData):
         self.cls.load()
         self.ns.load()
         self.music = base.loader.loadMusic('phase_3/audio/bgm/create_a_toon.ogg')
-        self.musicVolume = base.config.GetFloat('makeatoon-music-volume', 1)
-        self.sfxVolume = base.config.GetFloat('makeatoon-sfx-volume', 1)
+        self.musicVolume = ConfigVariableDouble('makeatoon-music-volume', 1).getValue()
+        self.sfxVolume = ConfigVariableDouble('makeatoon-sfx-volume', 1).getValue()
         self.soundBack = base.loader.loadSfx('phase_3/audio/sfx/GUI_create_toon_back.ogg')
         self.crashSounds = []
         self.crashSounds.append(base.loader.loadSfx('phase_3/audio/sfx/tt_s_ara_mat_crash_boing.ogg'))
@@ -598,7 +598,7 @@ class MakeAToon(StateData.StateData):
         self.ns.rejectName(TTLocalizer.RejectNameText)
 
     def __handleNameShopDone(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: MAKEATOON: Creating A Toon')
         self.guiLastButton.hide()
         self.guiCheckButton.hide()

--- a/toontown/makeatoon/NameShop.py
+++ b/toontown/makeatoon/NameShop.py
@@ -1,8 +1,8 @@
 from panda3d.core import *
+from panda3d.core import ConfigVariableBool, TextEncoder
 from toontown.toonbase.ToontownGlobals import *
 from direct.task.TaskManagerGlobal import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from toontown.distributed.ToontownMsgTypes import *
 from direct.directnotify import DirectNotifyGlobal
 from direct.gui import OnscreenText
@@ -24,7 +24,6 @@ from direct.showbase import PythonUtil
 from toontown.toon import NPCToons
 from direct.task import Task
 from toontown.makeatoon.TTPickANamePattern import TTPickANamePattern
-from panda3d.core import TextEncoder
 MAX_NAME_WIDTH = TTLocalizer.NSmaxNameWidth
 ServerDialogTimeout = 3.0
 
@@ -1176,12 +1175,12 @@ class NameShop(StateData.StateData):
     def __openTutorialDialog(self, choice = 0):
         if choice == 1:
             self.notify.debug('enterTutorial')
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: ENTERTUTORIAL: Enter Tutorial')
             self.__createAvatar()
         else:
             self.notify.debug('skipTutorial')
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: SKIPTUTORIAL: Skip Tutorial')
             self.__handleSkipTutorial()
         self.promptTutorialDialog.destroy()

--- a/toontown/minigame/CatchGameGlobals.py
+++ b/toontown/minigame/CatchGameGlobals.py
@@ -1,4 +1,6 @@
-EndlessGame = config.GetBool('endless-catch-game', 0)
+from panda3d.core import ConfigVariableBool
+
+EndlessGame = ConfigVariableBool('endless-catch-game', 0).getValue()
 GameDuration = 55.0
 
 class DropObject:

--- a/toontown/minigame/DistributedCannonGame.py
+++ b/toontown/minigame/DistributedCannonGame.py
@@ -1,4 +1,4 @@
-from panda3d.core import Point3, Quat, rad2Deg, Vec3
+from panda3d.core import ConfigVariableBool, Point3, Quat, rad2Deg, Vec3
 from panda3d.otp import Nametag, NametagFloat3d
 
 from direct.directnotify.DirectNotifyGlobal import directNotify
@@ -377,7 +377,7 @@ class DistributedCannonGame(DistributedMinigame):
         DistributedMinigame.setGameStart(self, timestamp)
         self.__stopIntro()
         self.__putCameraBehindCannon()
-        if not base.config.GetBool('endless-cannon-game', 0):
+        if not ConfigVariableBool('endless-cannon-game', 0).getValue():
             self.timer.show()
             self.timer.countdown(CannonGameGlobals.GameTime, self.__gameTimerExpired)
 

--- a/toontown/minigame/DistributedCannonGameAI.py
+++ b/toontown/minigame/DistributedCannonGameAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from .DistributedMinigameAI import *
 from direct.distributed.ClockDelta import *
 from direct.fsm import ClassicFSM, State
@@ -45,7 +46,7 @@ class DistributedCannonGameAI(DistributedMinigameAI):
 
     def enterPlay(self):
         self.notify.debug('enterPlay')
-        if not config.GetBool('endless-cannon-game', 0):
+        if not ConfigVariableBool('endless-cannon-game', 0).getValue():
             taskMgr.doMethodLater(CannonGameGlobals.GameTime, self.timerExpired, self.taskName('gameTimer'))
 
     def timerExpired(self, task):

--- a/toontown/minigame/DistributedCogThiefGame.py
+++ b/toontown/minigame/DistributedCogThiefGame.py
@@ -1,4 +1,4 @@
-from panda3d.core import Point3, CollisionSphere, CollisionNode, CollisionHandlerEvent, NodePath, TextNode
+from panda3d.core import Point3, CollisionSphere, CollisionNode, CollisionHandlerEvent, ConfigVariableBool, ConfigVariableDouble, ConfigVariableInt, NodePath, TextNode
 from direct.distributed.ClockDelta import globalClockDelta
 from direct.interval.IntervalGlobal import Wait, LerpFunctionInterval, LerpHprInterval, Sequence, Parallel, Func, SoundInterval, ActorInterval, ProjectileInterval, Track, LerpScaleInterval, WaitInterval, LerpPosHprInterval
 from direct.gui.DirectGui import DirectLabel
@@ -40,7 +40,7 @@ class DistributedCogThiefGame(DistributedMinigame):
         self.cogInfo = {}
         self.lastTimeControlPressed = 0
         self.stolenBarrels = []
-        self.useOrthoWalk = base.config.GetBool('cog-thief-ortho', 1)
+        self.useOrthoWalk = ConfigVariableBool('cog-thief-ortho', 1).getValue()
         self.resultIval = None
         self.gameIsEnding = False
         self.__textGen = TextNode('cogThiefGame')
@@ -248,7 +248,7 @@ class DistributedCogThiefGame(DistributedMinigame):
             return
         self.notify.debug('setGameStart')
         DistributedMinigame.setGameStart(self, timestamp)
-        if not base.config.GetBool('cog-thief-endless', 0):
+        if not ConfigVariableBool('cog-thief-endless', 0).getValue():
             self.timer.show()
             self.timer.countdown(CTGG.GameTime, self.__gameTimerExpired)
         self.clockStopTime = None
@@ -319,7 +319,7 @@ class DistributedCogThiefGame(DistributedMinigame):
         camera.reparentTo(render)
         p = self.cameraTopView
         camera.setPosHpr(p[0], p[1], p[2], p[3], p[4], p[5])
-        camera.setZ(camera.getZ() + base.config.GetFloat('cog-thief-z-camera-adjust', 0.0))
+        camera.setZ(camera.getZ() + ConfigVariableDouble('cog-thief-z-camera-adjust', 0.0).getValue())
 
     def destroyGameWalk(self):
         self.notify.debug('destroyOrthoWalk')
@@ -764,8 +764,8 @@ class DistributedCogThiefGame(DistributedMinigame):
             self.stolenBarrels.append(barrelIndex)
             barrel = self.barrels[barrelIndex]
             barrel.hide()
-        if base.config.GetBool('cog-thief-check-barrels', 1):
-            if not base.config.GetBool('cog-thief-endless', 0):
+        if ConfigVariableBool('cog-thief-check-barrels', 1).getValue():
+            if not ConfigVariableBool('cog-thief-endless', 0).getValue():
                 if len(self.stolenBarrels) == len(self.barrels):
                     localStamp = globalClockDelta.networkToLocalTime(timestamp, bits=32)
                     gameTime = self.local2GameTime(localStamp)
@@ -836,7 +836,7 @@ class DistributedCogThiefGame(DistributedMinigame):
         return False
 
     def getNumCogs(self):
-        result = base.config.GetInt('cog-thief-num-cogs', 0)
+        result = ConfigVariableInt('cog-thief-num-cogs', 0).getValue()
         if not result:
             safezone = self.getSafezoneId()
             result = CTGG.calculateCogs(self.numPlayers, safezone)

--- a/toontown/minigame/DistributedCogThiefGameAI.py
+++ b/toontown/minigame/DistributedCogThiefGameAI.py
@@ -1,5 +1,5 @@
 import random
-from panda3d.core import Point3
+from panda3d.core import ConfigVariableBool, ConfigVariableInt, Point3
 from direct.fsm import ClassicFSM
 from direct.fsm import State
 from direct.distributed.ClockDelta import globalClockDelta
@@ -74,7 +74,7 @@ class DistributedCogThiefGameAI(DistributedMinigameAI.DistributedMinigameAI):
     def enterPlay(self):
         self.notify.debug('enterPlay')
         self.startSuitGoals()
-        if not config.GetBool('cog-thief-endless', 0):
+        if not ConfigVariableBool('cog-thief-endless', 0).getValue():
             taskMgr.doMethodLater(CTGG.GameTime, self.timerExpired, self.taskName('gameTimer'))
 
     def exitPlay(self):
@@ -391,8 +391,8 @@ class DistributedCogThiefGameAI(DistributedMinigameAI.DistributedMinigameAI):
                 numStolen += 1
 
         self.notify.debug('numStolen = %s' % numStolen)
-        if simbase.config.GetBool('cog-thief-check-barrels', 1):
-            if not simbase.config.GetBool('cog-thief-endless', 0):
+        if ConfigVariableBool('cog-thief-check-barrels', 1).getValue():
+            if not ConfigVariableBool('cog-thief-endless', 0).getValue():
                 if numStolen == len(self.barrelInfo):
                     self.gameOver()
 
@@ -402,7 +402,7 @@ class DistributedCogThiefGameAI(DistributedMinigameAI.DistributedMinigameAI):
         return Task.done
 
     def getNumCogs(self):
-        result = simbase.config.GetInt('cog-thief-num-cogs', 0)
+        result = ConfigVariableInt('cog-thief-num-cogs', 0).getValue()
         if not result:
             safezone = self.getSafezoneId()
             result = CTGG.calculateCogs(self.numPlayers, safezone)

--- a/toontown/minigame/DistributedPhotoGame.py
+++ b/toontown/minigame/DistributedPhotoGame.py
@@ -14,7 +14,6 @@ import math
 from toontown.toon import ToonHead
 from . import PhotoGameGlobals
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 from toontown.golf import BuildGeometry
 from toontown.toon import Toon
@@ -894,7 +893,7 @@ class DistributedPhotoGame(DistributedMinigame, PhotoGameBase.PhotoGameBase):
         DistributedMinigame.setGameStart(self, timestamp)
         self.__stopIntro()
         self.__putCameraOnTripod()
-        if not base.config.GetBool('endless-cannon-game', 0):
+        if not ConfigVariableBool('endless-cannon-game', 0).getValue():
             self.timer.show()
             self.timer.countdown(self.data['TIME'], self.__gameTimerExpired)
         self.filmPanel.reparentTo(aspect2d)

--- a/toontown/minigame/DistributedPhotoGameAI.py
+++ b/toontown/minigame/DistributedPhotoGameAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from .DistributedMinigameAI import *
 from direct.distributed.ClockDelta import *
 from direct.fsm import ClassicFSM, State
@@ -55,7 +56,7 @@ class DistributedPhotoGameAI(DistributedMinigameAI, PhotoGameBase.PhotoGameBase)
 
     def enterPlay(self):
         self.notify.debug('enterPlay')
-        if not config.GetBool('endless-photo-game', 0):
+        if not ConfigVariableBool('endless-photo-game', 0).getValue():
             taskMgr.doMethodLater(self.data['TIME'], self.timerExpired, self.taskName('gameTimer'))
 
     def timerExpired(self, task = None):

--- a/toontown/minigame/DivingGameGlobals.py
+++ b/toontown/minigame/DivingGameGlobals.py
@@ -1,5 +1,7 @@
+from panda3d.core import ConfigVariableBool
 from toontown.toonbase import ToontownGlobals
-ENDLESS_GAME = config.GetBool('endless-maze-game', 0)
+
+ENDLESS_GAME = ConfigVariableBool('endless-maze-game', 0).getValue()
 NUM_SPAWNERS = 6
 GAME_DURATION = 60.0
 CollideMask = ToontownGlobals.CatchGameBitmask

--- a/toontown/minigame/MazeGameGlobals.py
+++ b/toontown/minigame/MazeGameGlobals.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.showbase import RandomNumGen
 
 def getMazeName(gameDoId, numPlayers, mazeNames):
@@ -8,7 +9,7 @@ def getMazeName(gameDoId, numPlayers, mazeNames):
         return names[RandomNumGen.randHash(gameDoId) % len(names)]
 
 
-ENDLESS_GAME = config.GetBool('endless-maze-game', 0)
+ENDLESS_GAME = ConfigVariableBool('endless-maze-game', 0).getValue()
 GAME_DURATION = 60.0
 SHOWSCORES_DURATION = 2.0
 SUIT_TIC_FREQ = int(256)

--- a/toontown/minigame/MinigameCreatorAI.py
+++ b/toontown/minigame/MinigameCreatorAI.py
@@ -1,6 +1,7 @@
 import copy
 import random
 import time
+from panda3d.core import ConfigVariableBool, ConfigVariableInt
 from toontown.toonbase import ToontownGlobals
 from . import DistributedMinigameTemplateAI
 from . import DistributedRaceGameAI
@@ -21,10 +22,10 @@ from . import DistributedCogThiefGameAI
 from . import DistributedTwoDGameAI
 from . import DistributedTravelGameAI
 from . import TravelGameGlobals
-ALLOW_TEMP_MINIGAMES = simbase.config.GetBool('allow-temp-minigames', False)
+ALLOW_TEMP_MINIGAMES = ConfigVariableBool('allow-temp-minigames', False).getValue()
 if ALLOW_TEMP_MINIGAMES:
     from toontown.minigame.TempMinigameAI import *
-simbase.forcedMinigameId = simbase.config.GetInt('minigame-id', 0)
+simbase.forcedMinigameId = ConfigVariableInt('minigame-id', 0).getValue()
 RequestMinigame = {}
 MinigameZoneRefs = {}
 
@@ -162,19 +163,19 @@ def removeUnreleasedMinigames(startList, increaseChanceOfNewGames = 0):
         if currentTime < releaseTime:
             if gameId in randomList:
                 doRemove = True
-                if gameId == ToontownGlobals.CogThiefGameId and simbase.air.config.GetBool('force-allow-thief-game', 0):
+                if gameId == ToontownGlobals.CogThiefGameId and ConfigVariableBool('force-allow-thief-game', 0).getValue():
                     doRemove = False
                     if increaseChanceOfNewGames:
                         randomList += [gameId] * 4
-                elif gameId == ToontownGlobals.IceGameId and simbase.air.config.GetBool('force-allow-ice-game', 0):
+                elif gameId == ToontownGlobals.IceGameId and ConfigVariableBool('force-allow-ice-game', 0).getValue():
                     doRemove = False
                     if increaseChanceOfNewGames:
                         randomList += [gameId] * 4
-                elif gameId == ToontownGlobals.TwoDGameId and simbase.air.config.GetBool('force-allow-2d-game', 0):
+                elif gameId == ToontownGlobals.TwoDGameId and ConfigVariableBool('force-allow-2d-game', 0).getValue():
                     doRemove = False
                     if increaseChanceOfNewGames:
                         randomList += [gameId] * 4
-                elif gameId == ToontownGlobals.PhotoGameId and simbase.air.config.GetBool('force-allow-photo-game', 0):
+                elif gameId == ToontownGlobals.PhotoGameId and ConfigVariableBool('force-allow-photo-game', 0).getValue():
                     doRemove = False
                     if increaseChanceOfNewGames:
                         randomList += [gameId] * 4

--- a/toontown/minigame/PairingGameGlobals.py
+++ b/toontown/minigame/PairingGameGlobals.py
@@ -1,7 +1,9 @@
+from panda3d.core import ConfigVariableBool
 from . import PlayingCardDeck
+
 EasiestGameDuration = 120
 HardestGameDuration = 90
-EndlessGame = config.GetBool('endless-pairing-game', 0)
+EndlessGame = ConfigVariableBool('endless-pairing-game', 0).getValue()
 MaxRankIndexUsed = [7,
  7,
  7,

--- a/toontown/minigame/Purchase.py
+++ b/toontown/minigame/Purchase.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from panda3d.otp import *
 from .PurchaseBase import *
 from direct.task.Task import Task
@@ -618,9 +619,9 @@ class Purchase(PurchaseBase):
             base.cr.loginFSM.request('periodTimeout')
             return
         if not self.tutorialMode:
-            if not config.GetBool('disable-purchase-timer', 0):
+            if not ConfigVariableBool('disable-purchase-timer', 0).getValue():
                 self.timer.countdown(self.remain, self.__timerExpired)
-            if config.GetBool('metagame-disable-playAgain', 0):
+            if ConfigVariableBool('metagame-disable-playAgain', 0).getValue():
                 if self.metagameRound > -1:
                     self.disablePlayAgain()
         else:

--- a/toontown/minigame/RingGameGlobals.py
+++ b/toontown/minigame/RingGameGlobals.py
@@ -1,7 +1,8 @@
 from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 from toontown.toonbase import ToontownGlobals
-ENDLESS_GAME = config.GetBool('endless-ring-game', 0)
+
+ENDLESS_GAME = ConfigVariableBool('endless-ring-game', 0).getValue()
 NUM_RING_GROUPS = 16
 MAX_TOONXZ = 10.0
 CollisionRadius = 1.5

--- a/toontown/minigame/TargetGameGlobals.py
+++ b/toontown/minigame/TargetGameGlobals.py
@@ -1,7 +1,8 @@
 from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 from toontown.toonbase import ToontownGlobals
-ENDLESS_GAME = config.GetBool('endless-ring-game', 0)
+
+ENDLESS_GAME = ConfigVariableBool('endless-ring-game', 0).getValue()
 NUM_RING_GROUPS = 16
 MAX_TOONXZ = 15.0
 MAX_LAT = 5

--- a/toontown/minigame/TempMinigameAI.py
+++ b/toontown/minigame/TempMinigameAI.py
@@ -1,5 +1,7 @@
+from panda3d.core import ConfigVariableBool
 from toontown.toonbase import ToontownGlobals
-ALLOW_TEMP_MINIGAMES = simbase.config.GetBool('allow-temp-minigames', False)
+
+ALLOW_TEMP_MINIGAMES = ConfigVariableBool('allow-temp-minigames', False).getValue()
 TEMP_MG_ID_COUNTER = ToontownGlobals.TravelGameId - 1
 TempMgCtors = {}
 

--- a/toontown/minigame/ToonBlitzGlobals.py
+++ b/toontown/minigame/ToonBlitzGlobals.py
@@ -1,7 +1,8 @@
+from panda3d.core import BitMask32, ConfigVariableBool
 from toontown.toonbase import ToontownGlobals
-from panda3d.core import BitMask32
+
 ShowScoresDuration = 4.0
-EndlessGame = config.GetBool('endless-2d-game', 0)
+EndlessGame = ConfigVariableBool('endless-2d-game', 0).getValue()
 ScoreToJellyBeansMultiplier = 5
 ScoreGainPerTreasure = 1
 ToonStartingPosition = (-39, 0, 13.59)

--- a/toontown/parties/CalendarGuiDay.py
+++ b/toontown/parties/CalendarGuiDay.py
@@ -1,7 +1,7 @@
 import datetime
 import functools
 import time
-from panda3d.core import TextNode, Vec3, Vec4, PlaneNode, Plane, Point3
+from panda3d.core import ConfigVariableBool, TextNode, Vec3, Vec4, PlaneNode, Plane, Point3
 from direct.gui.DirectGui import DirectFrame, DirectLabel, DirectButton, DirectScrolledList, DGG
 from direct.directnotify import DirectNotifyGlobal
 from direct.gui import DirectGuiGlobals
@@ -35,7 +35,7 @@ class CalendarGuiDay(DirectFrame):
         self.partiesInvitedToToday = []
         self.hostedPartiesToday = []
         self.yearlyHolidaysToday = []
-        self.showMarkers = base.config.GetBool('show-calendar-markers', 0)
+        self.showMarkers = ConfigVariableBool('show-calendar-markers', 0).getValue()
         self.filter = ToontownGlobals.CalendarFilterShowAll
         self.load()
         self.createGuiObjects()
@@ -182,7 +182,7 @@ class CalendarGuiDay(DirectFrame):
                 self.addTitleAndDescToScrollList(holidayName, holidayDesc)
 
             self.scrollList.refresh()
-        if base.config.GetBool('calendar-test-items', 0):
+        if ConfigVariableBool('calendar-test-items', 0).getValue():
             if self.myDate.date() + datetime.timedelta(days=-1) == base.cr.toontownTimeManager.getCurServerDateTime().date():
                 testItems = ('1:00 AM Party', '2:00 AM CEO', '11:15 AM Party', '5:30 PM CJ', '11:00 PM Party', 'Really Really Long String')
                 for text in testItems:

--- a/toontown/parties/CalendarGuiMonth.py
+++ b/toontown/parties/CalendarGuiMonth.py
@@ -1,6 +1,6 @@
 import calendar
 from datetime import timedelta, datetime
-from panda3d.core import Vec4, TextNode
+from panda3d.core import ConfigVariableBool, Vec4, TextNode
 from direct.gui.DirectGui import DirectFrame, DirectLabel, DirectButton, DirectScrolledList, DGG
 from toontown.toonbase import TTLocalizer
 from toontown.toonbase import ToontownGlobals
@@ -18,7 +18,7 @@ class CalendarGuiMonth(DirectFrame):
         if self.onlyFutureDaysClickable:
             self.onlyFutureMonthsClickable = True
         DirectFrame.__init__(self, parent=parent, scale=scale, pos=pos)
-        self.showMarkers = base.config.GetBool('show-calendar-markers', 0)
+        self.showMarkers = ConfigVariableBool('show-calendar-markers', 0).getValue()
         self.load()
         self.createGuiObjects()
         self.lastSelectedDate = None

--- a/toontown/parties/DistributedParty.py
+++ b/toontown/parties/DistributedParty.py
@@ -1,7 +1,7 @@
 import random
 import time
 import datetime
-from panda3d.core import Vec4, TextNode, CardMaker, NodePath
+from panda3d.core import Vec4, TextNode, CardMaker, NodePath, ConfigVariableBool
 from direct.distributed import DistributedObject
 from direct.gui.DirectGui import DirectLabel
 from direct.gui import OnscreenText
@@ -407,7 +407,7 @@ class DistributedParty(DistributedObject.DistributedObject):
         base.localAvatar.chatMgr.chatInputSpeedChat.addInsidePartiesMenu()
         self.spawnTitleText()
         messenger.send(self.generatedEvent)
-        if config.GetBool('show-debug-party-grid', 0):
+        if ConfigVariableBool('show-debug-party-grid', 0).getValue():
             self.testGrid = NodePath('test_grid')
             self.testGrid.reparentTo(base.cr.playGame.hood.loader.geom)
             for i in range(len(self.grid)):

--- a/toontown/parties/DistributedPartyTeamActivity.py
+++ b/toontown/parties/DistributedPartyTeamActivity.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from direct.distributed.ClockDelta import globalClockDelta
 from toontown.toonbase import TTLocalizer
 from toontown.parties import PartyGlobals
@@ -19,7 +20,7 @@ class DistributedPartyTeamActivity(DistributedPartyActivity):
         self._maxPlayersPerTeam = 0
         self._minPlayersPerTeam = 0
         self._duration = 0
-        self._startDelay = base.config.GetFloat('party-team-activity-start-delay', startDelay)
+        self._startDelay = ConfigVariableDouble('party-team-activity-start-delay', startDelay).getValue()
         self._willBalanceTeams = balanceTeams
         self._currentStatus = ''
         return

--- a/toontown/parties/Party.py
+++ b/toontown/parties/Party.py
@@ -99,7 +99,7 @@ class Party(Place.Place):
     def enter(self, requestStatus):
         hoodId = requestStatus['hoodId']
         zoneId = requestStatus['zoneId']
-        if config.GetBool('want-party-telemetry-limiter', 1):
+        if ConfigVariableBool('want-party-telemetry-limiter', 1).getValue():
             limiter = TLGatherAllAvs('Party', RotationLimitToH)
         else:
             limiter = TLNull()
@@ -275,7 +275,7 @@ class Party(Place.Place):
         if self.isPartyEnding:
             teleportNotify.debug('party ending, sending teleportResponse')
             fromAvatar.d_teleportResponse(toAvatar.doId, 0, toAvatar.defaultShard, base.cr.playGame.getPlaceId(), self.getZoneId())
-        elif base.config.GetBool('want-tptrack', False):
+        elif ConfigVariableBool('want-tptrack', False).getValue():
             if toAvatar == localAvatar:
                 localAvatar.doTeleportResponse(fromAvatar, toAvatar, toAvatar.doId, 1, toAvatar.defaultShard, base.cr.playGame.getPlaceId(), self.getZoneId(), fromAvatar.doId)
             else:

--- a/toontown/parties/PartyPlanner.py
+++ b/toontown/parties/PartyPlanner.py
@@ -1,7 +1,7 @@
 import calendar
 from datetime import datetime
 from datetime import timedelta
-from panda3d.core import Vec3, Vec4, Point3, TextNode, VBase4
+from panda3d.core import ConfigVariableInt, Vec3, Vec4, Point3, TextNode, VBase4
 from otp.otpbase import OTPLocalizer
 from direct.gui.DirectGui import DirectFrame, DirectButton, DirectLabel, DirectScrolledList, DirectCheckButton
 from direct.gui import DirectGuiGlobals
@@ -56,7 +56,7 @@ class PartyPlanner(DirectFrame, FSM):
          'minute': (15, -15),
          'ampm': (1, -1)}
         self.partyInfo = None
-        self.asapMinuteRounding = base.config.GetInt('party-asap-minute-rounding', PartyGlobals.PartyPlannerAsapMinuteRounding)
+        self.asapMinuteRounding = ConfigVariableInt('party-asap-minute-rounding', PartyGlobals.PartyPlannerAsapMinuteRounding).getValue()
         self.load()
         self.request('Welcome')
         return

--- a/toontown/parties/ToontownTimeManager.py
+++ b/toontown/parties/ToontownTimeManager.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timedelta
 import pytz
+from panda3d.core import ConfigVariableString
 from direct.directnotify import DirectNotifyGlobal
 from toontown.toonbase import TTLocalizer
 
@@ -10,14 +11,7 @@ class ToontownTimeManager:
     formatStr = '%Y-%m-%d %H:%M:%S'
 
     def __init__(self, serverTimeUponLogin = 0, clientTimeUponLogin = 0, globalClockRealTimeUponLogin = 0):
-        try:
-            self.serverTimeZoneString = base.config.GetString('server-timezone', TTLocalizer.TimeZone)
-        except:
-            try:
-                self.serverTimeZoneString = simbase.config.GetString('server-timezone', TTLocalizer.TimeZone)
-            except:
-                notify.error('ToontownTimeManager does not have access to base or simbase.')
-
+        self.serverTimeZoneString = ConfigVariableString('server-timezone', TTLocalizer.TimeZone).getValue()
         self.serverTimeZone = pytz.timezone(self.serverTimeZoneString)
         self.updateLoginTimes(serverTimeUponLogin, clientTimeUponLogin, globalClockRealTimeUponLogin)
         self.debugSecondsAdded = 0

--- a/toontown/pets/Pet.py
+++ b/toontown/pets/Pet.py
@@ -320,7 +320,7 @@ class Pet(Avatar.Avatar):
     def speakMood(self, mood):
         if self.moodModel:
             self.moodModel.hide()
-        if base.config.GetBool('want-speech-bubble', 1):
+        if ConfigVariableBool('want-speech-bubble', 1).getValue():
             self.nametag.setChat(random.choice(TTLocalizer.SpokenMoods[mood]), CFSpeech)
         else:
             self.nametag.setChat(random.choice(TTLocalizer.SpokenMoods[mood]), CFThought)

--- a/toontown/pets/PetAvatarPanel.py
+++ b/toontown/pets/PetAvatarPanel.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from direct.directnotify.DirectNotifyGlobal import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.showbase import DirectObject
 from direct.showbase.PythonUtil import Functor
 from direct.task.Task import Task
@@ -217,7 +216,7 @@ class PetAvatarPanel(AvatarPanel.AvatarPanel):
         return
 
     def __handleCall(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: PET: Call')
         self.notify.debug('__handleCall(): doId=%s' % self.avatar.doId)
         base.localAvatar.b_setPetMovie(self.avId, PetConstants.PET_MOVIE_CALL)
@@ -229,7 +228,7 @@ class PetAvatarPanel(AvatarPanel.AvatarPanel):
         return
 
     def __handleFeed(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: PET: Feed')
         self.notify.debug('__handleFeed(): doId=%s' % self.avatar.doId)
         base.localAvatar.b_setPetMovie(self.avId, PetConstants.PET_MOVIE_FEED)
@@ -241,7 +240,7 @@ class PetAvatarPanel(AvatarPanel.AvatarPanel):
         return
 
     def __handleScratch(self):
-        if base.config.GetBool('want-qa-regression', 1):
+        if ConfigVariableBool('want-qa-regression', 1).getValue():
             self.notify.info('QA-REGRESSION: PET: Scratch')
         self.notify.debug('__handleScratch(): doId=%s' % self.avatar.doId)
         base.localAvatar.b_setPetMovie(self.avId, PetConstants.PET_MOVIE_SCRATCH)

--- a/toontown/quest/QuestChoiceGui.py
+++ b/toontown/quest/QuestChoiceGui.py
@@ -55,7 +55,7 @@ class QuestChoiceGui(DirectFrame):
 
     def chooseQuest(self, questId):
         if questId != 0:
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: CREATEATASK: Create A Task.')
         base.setCellsAvailable(base.leftCells, 1)
         base.setCellsAvailable([base.bottomCells[0], base.bottomCells[1]], 1)

--- a/toontown/quest/QuestManagerAI.py
+++ b/toontown/quest/QuestManagerAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.task import Task
 from direct.directnotify import DirectNotifyGlobal
@@ -48,7 +49,7 @@ class QuestManagerAI:
     notify = DirectNotifyGlobal.directNotify.newCategory("QuestManagerAI")
 
     # Immediately complete all quests and all visits are to ToonHQ
-    QuestCheat = simbase.config.GetBool("quest-cheat", 0)
+    QuestCheat = ConfigVariableBool("quest-cheat", 0).getValue()
 
     # table of requests for quests from specific avatars
     NextQuestDict = {}

--- a/toontown/quest/QuestMap.py
+++ b/toontown/quest/QuestMap.py
@@ -1,5 +1,5 @@
 import math
-from panda3d.core import CardMaker, TextNode
+from panda3d.core import CardMaker, ConfigVariableBool, TextNode
 from direct.gui.DirectGui import DirectFrame, DirectLabel, DirectButton
 from direct.task import Task
 from toontown.toon import NPCToons
@@ -31,7 +31,7 @@ class QuestMap(DirectFrame):
         self.buildingMarkers = []
         self.av = av
         self.wantToggle = False
-        if base.config.GetBool('want-toggle-quest-map', True):
+        if ConfigVariableBool('want-toggle-quest-map', True).getValue():
             self.wantToggle = True
         self.updateMarker = True
         self.cornerPosInfo = None

--- a/toontown/quest/QuestParser.py
+++ b/toontown/quest/QuestParser.py
@@ -479,7 +479,7 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         token, varName, fileName = line
         if varName == 'tomDialogue_01':
             notify.debug('VarName tomDialogue getting added. Tutorial Ack: %d' % base.localAvatar.tutorialAck)
-        if base.config.GetString('language', 'english') == 'japanese':
+        if ConfigVariableString('language', 'english').getValue() == 'japanese':
             dialogue = base.loader.loadSfx(fileName)
         else:
             dialogue = None
@@ -493,7 +493,7 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         else:
             classicChar = 'minnie'
         filename = filenameTemplate % classicChar
-        if base.config.GetString('language', 'english') == 'japanese':
+        if ConfigVariableString('language', 'english').getValue() == 'japanese':
             dialogue = base.loader.loadSfx(filename)
         else:
             dialogue = None
@@ -1031,7 +1031,7 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         return Sequence(Func(grabCurTrackAccess), LerpFunctionInterval(updateGagLevel, fromData=1, toData=7, duration=0.3), WaitInterval(3.5), LerpFunctionInterval(updateGagLevel, fromData=7, toData=1, duration=0.3), Func(restoreTrackAccess), Func(messenger.send, 'doneThrowSquirtPreview'))
 
     def parseSetMusicVolume(self, line):
-        if base.config.GetString('language', 'english') == 'japanese':
+        if ConfigVariableString('language', 'english').getValue() == 'japanese':
             try:
                 loader = base.cr.playGame.place.loader
                 type = 'music'

--- a/toontown/quest/Quests.py
+++ b/toontown/quest/Quests.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.otpbase import OTPGlobals
 from toontown.toonbase import ToontownBattleGlobals
 from toontown.toonbase import ToontownGlobals
@@ -1743,7 +1744,7 @@ class TrackChoiceQuest(Quest):
 
 class FriendQuest(Quest):
     def filterFunc(avatar):
-        if not config.GetBool('skip-friend-quest', False) and len(avatar.getFriendsList()) == 0:
+        if not ConfigVariableBool('skip-friend-quest', False).getValue() and len(avatar.getFriendsList()) == 0:
             return 1
         else:
             return 0
@@ -1889,7 +1890,7 @@ class MailboxQuest(Quest):
 
 class PhoneQuest(Quest):
     def filterFunc(avatar):
-        if not config.GetBool('skip-phone-quest', False):
+        if not ConfigVariableBool('skip-phone-quest', False).getValue():
             return 1
         else:
             return 0

--- a/toontown/racing/DistributedStartingBlock.py
+++ b/toontown/racing/DistributedStartingBlock.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.ClockDelta import *
 from direct.interval.IntervalGlobal import *
 from toontown.building.ElevatorConstants import *
@@ -489,7 +490,7 @@ class DistributedStartingBlock(DistributedObject.DistributedObject, FSM):
 
     def enterEnterMovie(self):
         self.notify.debug('%d enterEnterMovie: Entering the Enter Movie State.' % self.doId)
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             raceName = TTLocalizer.KartRace_RaceNames[self.kartPad.trackType]
             self.notify.info('QA-REGRESSION: KARTING: %s' % raceName)
         toonTrack = self.generateToonMoveTrack()
@@ -670,7 +671,7 @@ class DistributedViewingBlock(DistributedStartingBlock):
 
     def enterEnterMovie(self):
         self.notify.debug('%d enterEnterMovie: Entering the Enter Movie State.' % self.doId)
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             raceName = TTLocalizer.KartRace_RaceNames[self.kartPad.trackType]
             self.notify.info('QA-REGRESSION: KARTING: %s' % raceName)
         pos = self.nodePath.getPos(render)

--- a/toontown/racing/DistributedVehicle.py
+++ b/toontown/racing/DistributedVehicle.py
@@ -3,7 +3,6 @@ from panda3d.otp import *
 from direct.distributed.ClockDelta import *
 from direct.interval.IntervalGlobal import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from panda3d.physics import *
 from direct.fsm import FSM
 from direct.distributed import DistributedSmoothNode
@@ -84,7 +83,7 @@ class DistributedVehicle(DistributedSmoothNode.DistributedSmoothNode, Kart.Kart,
         DistributedSmoothNode.DistributedSmoothNode.__init__(self, cr)
         FSM.FSM.__init__(self, 'DistributedVehicle')
         Kart.Kart.__init__(self)
-        if base.config.GetBool('want-racer', 0) == 1:
+        if ConfigVariableBool('want-racer', 0).getValue() == 1:
             DistributedVehicle.proRacer = 1
             DistributedVehicle.accelerationMult = 35
             DistributedVehicle.accelerationBase = 30

--- a/toontown/racing/Kart.py
+++ b/toontown/racing/Kart.py
@@ -60,13 +60,13 @@ class Kart(NodePath, ShadowCaster.ShadowCaster):
         self.pitchNode = {}
         self.toonNode = {}
         self.rotateNode = self.attachNewNode('rotate')
-        levelIn = [base.config.GetInt('lod1-in', 30), base.config.GetInt('lod2-in', 80), base.config.GetInt('lod2-in', 200)]
-        levelOut = [base.config.GetInt('lod1-out', 0), base.config.GetInt('lod2-out', 30), base.config.GetInt('lod2-out', 80)]
+        levelIn = [ConfigVariableInt('lod1-in', 30).getValue(), ConfigVariableInt('lod2-in', 80).getValue(), ConfigVariableInt('lod2-in', 200).getValue()]
+        levelOut = [ConfigVariableInt('lod1-out', 0).getValue(), ConfigVariableInt('lod2-out', 30).getValue(), ConfigVariableInt('lod2-out', 80).getValue()]
         lodRequired = 3
         if forGui:
             lodRequired = 1
-            levelIn[0] = base.config.GetInt('lod1-in', 2500)
-            levelIn[1] = base.config.GetInt('lod1-out', 0)
+            levelIn[0] = ConfigVariableInt('lod1-in', 2500).getValue()
+            levelIn[1] = ConfigVariableInt('lod1-out', 0).getValue()
         self.toonSeat = NodePath('toonSeat')
         for level in range(lodRequired):
             self.__createLODKart(level)

--- a/toontown/safezone/DDPlayground.py
+++ b/toontown/safezone/DDPlayground.py
@@ -92,7 +92,7 @@ class DDPlayground(Playground.Playground):
         if self.toonSubmerged == 1:
             return
         base.playSfx(self.loader.submergeSound)
-        if base.config.GetBool('disable-flying-glitch') == 0:
+        if ConfigVariableBool('disable-flying-glitch').getValue() == 0:
             self.fsm.request('walk')
         self.walkStateData.fsm.request('swimming', [self.loader.swimSound])
         pos = base.localAvatar.getPos(render)

--- a/toontown/safezone/DistributedFishingSpot.py
+++ b/toontown/safezone/DistributedFishingSpot.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from direct.interval.IntervalGlobal import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.directtools.DirectGeometry import LineNodePath
 from direct.distributed import DistributedObject
 from direct.directnotify import DirectNotifyGlobal
@@ -14,7 +13,6 @@ from direct.actor import Actor
 from direct.showutil import Rope
 import math
 from direct.task.Task import Task
-import random
 import random
 from toontown.fishing import FishingTargetGlobals
 from toontown.fishing import FishBase
@@ -578,7 +576,7 @@ class DistributedFishingSpot(DistributedObject.DistributedObject):
         self.itemGui.detachNode()
 
     def __makeGui(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: FISHING: ZoneId: %s' % self.pond.getArea())
         if self.madeGui:
             return
@@ -862,7 +860,7 @@ class DistributedFishingSpot(DistributedObject.DistributedObject):
         self.initMouseX = self.mouseX
         self.initMouseY = self.mouseY
         self.__hideBob()
-        if config.GetBool('fishing-independent-axes', 0):
+        if ConfigVariableBool('fishing-independent-axes', 0).getValue():
             taskMgr.add(self.localAdjustingCastTaskIndAxes, self.taskName('adjustCastTask'))
         else:
             taskMgr.add(self.localAdjustingCastTask, self.taskName('adjustCastTask'))

--- a/toontown/safezone/DistributedGolfKart.py
+++ b/toontown/safezone/DistributedGolfKart.py
@@ -31,7 +31,7 @@ class DistributedGolfKart(DistributedObject.DistributedObject):
     def __init__(self, cr):
         DistributedObject.DistributedObject.__init__(self, cr)
         self.localToonOnBoard = 0
-        self.trolleyCountdownTime = base.config.GetFloat('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME)
+        self.trolleyCountdownTime = ConfigVariableDouble('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME).getValue()
         self.fsm = ClassicFSM.ClassicFSM('DistributedTrolley', [State.State('off', self.enterOff, self.exitOff, ['entering',
           'waitEmpty',
           'waitCountdown',

--- a/toontown/safezone/DistributedGolfKartAI.py
+++ b/toontown/safezone/DistributedGolfKartAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from otp.ai.AIBase import *
 from toontown.toonbase.ToontownGlobals import *
 from direct.distributed.ClockDelta import *
@@ -35,7 +36,7 @@ class DistributedGolfKartAI(DistributedObjectAI.DistributedObjectAI):
                 self.color = (
                  self.color[0], 255, self.color[2])
         self.accepting = 0
-        self.trolleyCountdownTime = simbase.config.GetFloat('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME)
+        self.trolleyCountdownTime = ConfigVariableDouble('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME).getValue()
         self.fsm = ClassicFSM.ClassicFSM('DistributedGolfKartAI', [
          State.State('off', self.enterOff, self.exitOff, [
           'entering']),

--- a/toontown/safezone/DistributedPicnicBasket.py
+++ b/toontown/safezone/DistributedPicnicBasket.py
@@ -27,7 +27,7 @@ class DistributedPicnicBasket(DistributedObject.DistributedObject):
         self.localToonOnBoard = 0
         self.seed = 0
         self.random = None
-        self.picnicCountdownTime = base.config.GetFloat('picnic-countdown-time', ToontownGlobals.PICNIC_COUNTDOWN_TIME)
+        self.picnicCountdownTime = ConfigVariableDouble('picnic-countdown-time', ToontownGlobals.PICNIC_COUNTDOWN_TIME).getValue()
         self.picnicBasketTrack = None
         self.fsm = ClassicFSM.ClassicFSM('DistributedTrolley', [State.State('off', self.enterOff, self.exitOff, ['waitEmpty', 'waitCountdown']), State.State('waitEmpty', self.enterWaitEmpty, self.exitWaitEmpty, ['waitCountdown']), State.State('waitCountdown', self.enterWaitCountdown, self.exitWaitCountdown, ['waitEmpty'])], 'off', 'off')
         self.fsm.enterInitialState()

--- a/toontown/safezone/DistributedPicnicBasketAI.py
+++ b/toontown/safezone/DistributedPicnicBasketAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableDouble
 from otp.ai.AIBase import *
 from toontown.toonbase.ToontownGlobals import *
 from direct.distributed.ClockDelta import *
@@ -27,7 +28,7 @@ class DistributedPicnicBasketAI(DistributedObjectAI.DistributedObjectAI):
         self.seed = RandomNumGen.randHash(globalClock.getRealTime())
         self.accepting = 0
         self.numPlayersExiting = 0
-        self.trolleyCountdownTime = simbase.config.GetFloat('picnic-countdown-time', ToontownGlobals.PICNIC_COUNTDOWN_TIME)
+        self.trolleyCountdownTime = ConfigVariableDouble('picnic-countdown-time', ToontownGlobals.PICNIC_COUNTDOWN_TIME).getValue()
         self.fsm = ClassicFSM.ClassicFSM('DistributedPicnicBasketAI', [
          State.State('off', self.enterOff, self.exitOff, [
           'waitEmpty']),

--- a/toontown/safezone/DistributedPicnicTableAI.py
+++ b/toontown/safezone/DistributedPicnicTableAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.distributed.DistributedNodeAI import DistributedNodeAI
 from direct.distributed.ClockDelta import *
 from direct.fsm import ClassicFSM, State
@@ -135,18 +136,18 @@ class DistributedPicnicTableAI(DistributedNodeAI):
                 x += 1
 
         if gameNum == 1:
-            if simbase.config.GetBool('want-chinese', 0):
+            if ConfigVariableBool('want-chinese', 0).getValue():
                 self.game = DistributedChineseCheckersAI.DistributedChineseCheckersAI(self.air, self.doId, 'chinese', self.getX(), self.getY(), self.getZ() + 2.83, self.getH(), self.getP(), self.getR())
                 self.sendUpdate('setZone', [self.game.zoneId])
         else:
             if gameNum == 2:
                 if x <= 2:
-                    if simbase.config.GetBool('want-checkers', 0):
+                    if ConfigVariableBool('want-checkers', 0).getValue():
                         self.game = DistributedCheckersAI.DistributedCheckersAI(self.air, self.doId, 'checkers', self.getX(), self.getY(), self.getZ() + 2.83, self.getH(), self.getP(), self.getR())
                         self.sendUpdate('setZone', [self.game.zoneId])
             else:
                 if x <= 2:
-                    if simbase.config.GetBool('want-findfour', 0):
+                    if ConfigVariableBool('want-findfour', 0).getValue():
                         self.game = DistributedFindFourAI.DistributedFindFourAI(self.air, self.doId, 'findFour', self.getX(), self.getY(), self.getZ() + 2.83, self.getH(), self.getP(), self.getR())
                         self.sendUpdate('setZone', [self.game.zoneId])
         return

--- a/toontown/safezone/DistributedTrolley.py
+++ b/toontown/safezone/DistributedTrolley.py
@@ -19,7 +19,7 @@ class DistributedTrolley(DistributedObject.DistributedObject):
     def __init__(self, cr):
         DistributedObject.DistributedObject.__init__(self, cr)
         self.localToonOnBoard = 0
-        self.trolleyCountdownTime = base.config.GetFloat('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME)
+        self.trolleyCountdownTime = ConfigVariableDouble('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME).getValue()
         self.fsm = ClassicFSM.ClassicFSM('DistributedTrolley', [State.State('off', self.enterOff, self.exitOff, ['entering',
           'waitEmpty',
           'waitCountdown',

--- a/toontown/safezone/DistributedTrolleyAI.py
+++ b/toontown/safezone/DistributedTrolleyAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool, ConfigVariableDouble
 from otp.ai.AIBase import *
 from toontown.toonbase.ToontownGlobals import *
 from direct.distributed.ClockDelta import *
@@ -21,7 +22,7 @@ class DistributedTrolleyAI(DistributedObjectAI.DistributedObjectAI):
         self.seats = [
          None, None, None, None]
         self.accepting = 0
-        self.trolleyCountdownTime = simbase.config.GetFloat('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME)
+        self.trolleyCountdownTime = ConfigVariableDouble('trolley-countdown-time', TROLLEY_COUNTDOWN_TIME).getValue()
         self.fsm = ClassicFSM.ClassicFSM('DistributedTrolleyAI', [
          State.State('off', self.enterOff, self.exitOff, [
           'entering']),
@@ -298,12 +299,12 @@ class DistributedTrolleyAI(DistributedObjectAI.DistributedObjectAI):
 
             startingVotes = None
             metagameRound = -1
-            trolleyGoesToMetagame = simbase.config.GetBool('trolley-goes-to-metagame', 0)
+            trolleyGoesToMetagame = ConfigVariableBool('trolley-goes-to-metagame', 0).getValue()
             trolleyHoliday = bboard.get(TrolleyHolidayMgrAI.TrolleyHolidayMgrAI.PostName)
             trolleyWeekend = bboard.get(TrolleyWeekendMgrAI.TrolleyWeekendMgrAI.PostName)
             if trolleyGoesToMetagame or trolleyHoliday or trolleyWeekend:
                 metagameRound = 0
-                if simbase.config.GetBool('metagame-min-2-players', 1) and len(playerArray) == 1:
+                if ConfigVariableBool('metagame-min-2-players', 1).getValue() and len(playerArray) == 1:
                     metagameRound = -1
             mgDict = MinigameCreatorAI.createMinigame(self.air, playerArray, self.zoneId, newbieIds=newbieIds, startingVotes=startingVotes, metagameRound=metagameRound)
             minigameZone = mgDict['minigameZone']

--- a/toontown/safezone/GSSafeZoneLoader.py
+++ b/toontown/safezone/GSSafeZoneLoader.py
@@ -99,7 +99,7 @@ class GSSafeZoneLoader(SafeZoneLoader):
         return
 
     def startSmokeEffect(self):
-        if base.config.GetBool('want-crashedLeaderBoard-Smoke', 1):
+        if ConfigVariableBool('want-crashedLeaderBoard-Smoke', 1).getValue():
             leaderBoard = self.geom.find('**/*crashed*')
             locator = leaderBoard.find('**/*locator_smoke*')
             if locator != None:
@@ -108,7 +108,7 @@ class GSSafeZoneLoader(SafeZoneLoader):
         return
 
     def stopSmokeEffect(self):
-        if base.config.GetBool('want-crashedLeaderBoard-Smoke', 1):
+        if ConfigVariableBool('want-crashedLeaderBoard-Smoke', 1).getValue():
             if self.smoke != None:
                 self.smoke.stop()
                 self.smoke.destroy()

--- a/toontown/safezone/GameMenu.py
+++ b/toontown/safezone/GameMenu.py
@@ -63,13 +63,13 @@ class GameMenu(DirectFrame):
             relief=0,
             pos=(-0.8, 0, -0.7),
             command=self.findFourSelected)
-        if not base.config.GetBool('want-chinese', 0):
+        if not ConfigVariableBool('want-chinese', 0).getValue():
             self.ChineseCheckers['command'] = self.doNothing
             self.ChineseCheckers.setColor(0.7, 0.7, 0.7, 0.7)
-        if not base.config.GetBool('want-checkers', 0):
+        if not ConfigVariableBool('want-checkers', 0).getValue():
             self.Checkers['command'] = self.doNothing
             self.Checkers.setColor(0.7, 0.7, 0.7, 0.7)
-        if not base.config.GetBool('want-findfour', 0):
+        if not ConfigVariableBool('want-findfour', 0).getValue():
             self.FindFour['command'] = self.doNothing
             self.FindFour.setColor(0.7, 0.7, 0.7, 0.7)
         self.chineseText = OnscreenText(

--- a/toontown/safezone/OZPlayground.py
+++ b/toontown/safezone/OZPlayground.py
@@ -92,7 +92,7 @@ class OZPlayground(Playground.Playground):
         if self.toonSubmerged == 1:
             return
         base.playSfx(self.loader.submergeSound)
-        if base.config.GetBool('disable-flying-glitch') == 0:
+        if ConfigVariableBool('disable-flying-glitch').getValue() == 0:
             self.fsm.request('walk')
         self.walkStateData.fsm.request('swimming', [self.loader.swimSound])
         pos = base.localAvatar.getPos(render)

--- a/toontown/shtiker/HtmlView.py
+++ b/toontown/shtiker/HtmlView.py
@@ -1,18 +1,9 @@
 import array, sys
+from panda3d.core import AwWebCore, AwWebView, CardMaker, ConfigVariableBool, NodePath, PNMImage, Point2, Point3, Texture, TextureStage, VBase4D, Vec3, Vec4, WindowProperties
 from direct.showbase.DirectObject import DirectObject
 from direct.task.Task import Task
 from direct.directnotify import DirectNotifyGlobal
-from panda3d.core import Texture
-from panda3d.core import CardMaker
-from panda3d.core import NodePath
-from panda3d.core import Point3, Vec3, Vec4, VBase4D, Point2
-from panda3d.core import PNMImage
-from panda3d.core import TextureStage
-from panda3d.core import Texture
-from panda3d.core import WindowProperties
 from direct.interval.IntervalGlobal import *
-from panda3d.core import AwWebView
-from panda3d.core import AwWebCore
 WEB_WIDTH_PIXELS = 784
 WEB_HEIGHT_PIXELS = 451
 WEB_WIDTH = 1024
@@ -24,7 +15,7 @@ GlobalWebcore = None
 
 class HtmlView(DirectObject):
     notify = DirectNotifyGlobal.directNotify.newCategory('HtmlView')
-    useHalfTexture = base.config.GetBool('news-half-texture', 0)
+    useHalfTexture = ConfigVariableBool('news-half-texture', 0).getValue()
 
     def __init__(self, parent = aspect2d):
         global GlobalWebcore
@@ -75,8 +66,8 @@ class HtmlView(DirectObject):
         self.accept('mouse3-up', self.mouseUp, [AwWebView.RIGHTMOUSEBTN])
 
     def getInGameNewsUrl(self):
-        result = base.config.GetString('fallback-news-url', 'http://cdn.toontown.disney.go.com/toontown/en/gamenews/')
-        override = base.config.GetString('in-game-news-url', '')
+        result = ConfigVariableString('fallback-news-url', 'http://cdn.toontown.disney.go.com/toontown/en/gamenews/').getValue()
+        override = ConfigVariableString('in-game-news-url', '').getValue()
         if override:
             self.notify.info('got an override url,  using %s for in a game news' % override)
             result = override

--- a/toontown/shtiker/IssueFrame.py
+++ b/toontown/shtiker/IssueFrame.py
@@ -1,8 +1,5 @@
 import os
-from panda3d.core import VirtualFileSystem, Filename, DSearchPath
-from panda3d.core import Texture, CardMaker, PNMImage, TextureStage
-from panda3d.core import NodePath
-from panda3d.core import Point2
+from panda3d.core import VirtualFileSystem, Filename, DSearchPath, Texture, CardMaker, PNMImage, TextureStage, NodePath, Point2, ConfigVariableBool, ConfigVariableString
 from direct.showbase import DirectObject
 from direct.gui.DirectGui import DirectFrame, DirectButton, DGG, DirectLabel
 from direct.directnotify import DirectNotifyGlobal
@@ -17,7 +14,7 @@ WIN_WIDTH = 800
 WIN_HEIGHT = 600
 
 class IssueFrame(DirectFrame):
-    NewsBaseDir = config.GetString('news-base-dir', '/httpNews')
+    NewsBaseDir = ConfigVariableString('news-base-dir', '/httpNews').getValue()
     FrameDimensions = (-1.30666637421,
      1.30666637421,
      -0.751666665077,
@@ -323,7 +320,7 @@ class IssueFrame(DirectFrame):
         return
 
     def gotoPage(self, section, subsection):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: INGAMENEWS: Goto Page')
         self.sectionFrames[self.curSection][self.curSubsection].hide()
         self.sectionFrames[section][subsection].show()
@@ -386,6 +383,6 @@ class IssueFrame(DirectFrame):
         pass
 
     def changeWeek(self, newIssueWeek):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: INGAMENEWS: Change Week')
         messenger.send('newsChangeWeek', [newIssueWeek])

--- a/toontown/shtiker/MapPage.py
+++ b/toontown/shtiker/MapPage.py
@@ -226,7 +226,7 @@ class MapPage(ShtikerPage.ShtikerPage):
         messenger.send(self.doneEvent)
 
     def goHome(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: VISITESTATE: Visit estate')
         self.doneStatus = {'mode': 'gohome',
          'hood': base.localAvatar.lastHood}

--- a/toontown/shtiker/NewsPage.py
+++ b/toontown/shtiker/NewsPage.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from direct.fsm import StateData
 from direct.gui.DirectGui import DirectFrame
 from direct.gui.DirectGui import DGG
@@ -6,7 +7,8 @@ from direct.directnotify import DirectNotifyGlobal
 from toontown.toonbase import ToontownGlobals
 from toontown.shtiker import ShtikerPage
 from toontown.toonbase import TTLocalizer
-UseDirectNewsFrame = config.GetBool('use-direct-news-frame', True)
+
+UseDirectNewsFrame = ConfigVariableBool('use-direct-news-frame', True).getValue()
 HaveNewsFrame = True
 if UseDirectNewsFrame:
     from toontown.shtiker import DirectNewsFrame

--- a/toontown/shtiker/PurchaseManagerAI.py
+++ b/toontown/shtiker/PurchaseManagerAI.py
@@ -133,7 +133,7 @@ class PurchaseManagerAI(DistributedObjectAI.DistributedObjectAI):
         return globalClockDelta.getRealNetworkTime()
 
     def startCountdown(self):
-        if not config.GetBool('disable-purchase-timer', 0):
+        if not ConfigVariableBool('disable-purchase-timer', 0).getValue():
             taskMgr.doMethodLater(PURCHASE_COUNTDOWN_TIME, self.timeIsUpTask, self.uniqueName('countdown-timer'))
 
     def requestExit(self):
@@ -286,7 +286,7 @@ class PurchaseManagerAI(DistributedObjectAI.DistributedObjectAI):
                 else:
                     newRound = 0
                     newVotesArray = [TravelGameGlobals.DefaultStartingVotes] * len(playAgainList)
-            if len(playAgainList) == 1 and simbase.config.GetBool('metagame-min-2-players', 1):
+            if len(playAgainList) == 1 and ConfigVariableBool('metagame-min-2-players', 1).getValue():
                 newRound = -1
             MinigameCreatorAI.createMinigame(self.air, playAgainList, self.trolleyZone, minigameZone=self.zoneId, previousGameId=self.previousMinigameId, newbieIds=newbieIdsToPass, startingVotes=newVotesArray, metagameRound=newRound, desiredNextGame=self.desiredNextGame)
         else:

--- a/toontown/shtiker/ShardPage.py
+++ b/toontown/shtiker/ShardPage.py
@@ -2,7 +2,6 @@ from panda3d.core import *
 from . import ShtikerPage
 from direct.task.Task import Task
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 from direct.directnotify import DirectNotifyGlobal
 from toontown.hood import ZoneUtil
@@ -10,6 +9,7 @@ from toontown.toonbase import ToontownGlobals
 from toontown.distributed import ToontownDistrictStats
 from toontown.toontowngui import TTDialog
 import functools
+
 POP_COLORS_NTT = (Vec4(0.0, 1.0, 0.0, 1.0), Vec4(1.0, 1.0, 0.0, 1.0), Vec4(1.0, 0.0, 0.0, 1.0))
 POP_COLORS = (Vec4(0.4, 0.4, 1.0, 1.0), Vec4(0.4, 1.0, 0.4, 1.0), Vec4(1.0, 0.4, 0.4, 1.0))
 
@@ -26,8 +26,8 @@ class ShardPage(ShtikerPage.ShtikerPage):
         self.textDisabledColor = Vec4(0.4, 0.8, 0.4, 1)
         self.ShardInfoUpdateInterval = 5.0
         self.lowPop, self.midPop, self.highPop = base.getShardPopLimits()
-        self.showPop = config.GetBool('show-total-population', 0)
-        self.noTeleport = config.GetBool('shard-page-disable', 0)
+        self.showPop = ConfigVariableBool('show-total-population', 0).getValue()
+        self.noTeleport = ConfigVariableBool('shard-page-disable', 0).getValue()
         return
 
     def load(self):

--- a/toontown/shtiker/ShtikerBook.py
+++ b/toontown/shtiker/ShtikerBook.py
@@ -4,7 +4,6 @@ from toontown.toonbase import ToontownGlobals
 from direct.showbase import DirectObject
 from direct.fsm import StateData
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 from toontown.effects import DistributedFireworkShow
 from toontown.parties import DistributedPartyFireworksActivity
@@ -52,7 +51,7 @@ class ShtikerBook(DirectFrame, StateData.StateData):
         self.safeMode = setting
 
     def enter(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: SHTICKERBOOK: Open')
         if self.entered:
             return
@@ -114,7 +113,7 @@ class ShtikerBook(DirectFrame, StateData.StateData):
         self.ignore(ToontownGlobals.OptionsPageHotkey)
         self.ignore('arrow_right')
         self.ignore('arrow_left')
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: SHTICKERBOOK: Close')
 
     def load(self):
@@ -193,7 +192,7 @@ class ShtikerBook(DirectFrame, StateData.StateData):
             messenger.send('wakeup')
             base.playSfx(self.pageSound)
             self.setPage(page)
-            if base.config.GetBool('want-qa-regression', 0):
+            if ConfigVariableBool('want-qa-regression', 0).getValue():
                 self.notify.info('QA-REGRESSION: SHTICKERBOOK: Browse tabs %s' % page.pageName)
             localAvatar.newsButtonMgr.setGoingToNewsPageFromStickerBook(False)
             localAvatar.newsButtonMgr.showAppropriateButton()
@@ -429,7 +428,7 @@ class ShtikerBook(DirectFrame, StateData.StateData):
         localAvatar.newsButtonMgr.setGoingToNewsPageFromStickerBook(True)
         localAvatar.newsButtonMgr.showAppropriateButton()
         self.setPage(page)
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: SHTICKERBOOK: Browse tabs %s' % page.pageName)
         self.ignore(ToontownGlobals.StickerBookHotkey)
         self.ignore(ToontownGlobals.OptionsPageHotkey)

--- a/toontown/spellbook/MagicWordConfig.py
+++ b/toontown/spellbook/MagicWordConfig.py
@@ -8,6 +8,7 @@
 # Version: 1.0.0
 # Email: belloqzafarian@gmail.com
 ##################################################
+from panda3d.core import ConfigVariableBool
 
 OUTGOING_CHAT_MESSAGE_NAME = 'magicWord'
 CLICKED_NAMETAG_MESSAGE_NAME = 'clickedNametag'
@@ -15,7 +16,7 @@ FOCUS_OUT_MESSAGE_NAME = 'focusOut'
 
 PREFIX_DEFAULT = '~'
 PREFIX_ALLOWED = ['~', '?', '/', '<', ':', ';']
-if config.GetBool('exec-chat', False):
+if ConfigVariableBool('exec-chat', False).getValue():
     PREFIX_ALLOWED.append('>')
 
 WIZARD_DEFAULT = 'Spellbook'

--- a/toontown/suit/DistributedBossbotBossAI.py
+++ b/toontown/suit/DistributedBossbotBossAI.py
@@ -1,5 +1,5 @@
 import random, math
-from panda3d.core import Point3
+from panda3d.core import ConfigVariableBool, ConfigVariableInt, Point3
 from direct.directnotify import DirectNotifyGlobal
 from direct.fsm import FSM
 from direct.interval.IntervalGlobal import LerpPosInterval
@@ -58,8 +58,8 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
         self.toonupsGranted = []
         self.doneOvertimeOneAttack = False
         self.doneOvertimeTwoAttack = False
-        self.overtimeOneTime = simbase.air.config.GetInt('overtime-one-time', 1200)
-        self.battleFourDuration = simbase.air.config.GetInt('battle-four-duration', 1800)
+        self.overtimeOneTime = ConfigVariableInt('overtime-one-time', 1200).getValue()
+        self.battleFourDuration = ConfigVariableInt('battle-four-duration', 1800).getValue()
         self.overtimeOneStart = float(self.overtimeOneTime) / self.battleFourDuration
         self.moveAttackAllowed = True
 
@@ -94,7 +94,7 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
             weakenedValue = (
              (1, 1), (2, 2), (2, 2), (1, 1), (1, 1, 1, 1, 1))
             listVersion = list(SuitBuildingGlobals.SuitBuildingInfo)
-            if simbase.config.GetBool('bossbot-boss-cheat', 0):
+            if ConfigVariableBool('bossbot-boss-cheat', 0).getValue():
                 listVersion[14] = weakenedValue
                 SuitBuildingGlobals.SuitBuildingInfo = tuple(listVersion)
             retval = self.invokeSuitPlanner(14, 0)
@@ -329,7 +329,7 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
     def generateDinerSuits(self):
         diners = []
         for i in range(len(self.notDeadList)):
-            if simbase.config.GetBool('bossbot-boss-cheat', 0):
+            if ConfigVariableBool('bossbot-boss-cheat', 0).getValue():
                 suit = self.__genSuitObject(self.zoneId, 2, 'c', 2, 0)
             else:
                 info = self.notDeadList[i]
@@ -340,7 +340,7 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
 
         active = []
         for i in range(2):
-            if simbase.config.GetBool('bossbot-boss-cheat', 0):
+            if ConfigVariableBool('bossbot-boss-cheat', 0).getValue():
                 suit = self.__genSuitObject(self.zoneId, 2, 'c', 2, 0)
             else:
                 suitType = 8
@@ -645,7 +645,7 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
                 self.b_setAttackCode(ToontownGlobals.BossCogGolfAttack, toonId)
                 self.numGolfAttacks += 1
             elif self.isToonOnTable(toonId):
-                doesMoveAttack = simbase.air.config.GetBool('ceo-does-move-attack', 1)
+                doesMoveAttack = ConfigVariableBool('ceo-does-move-attack', 1).getValue()
                 if doesMoveAttack:
                     chanceToShoot = 0.25
                 else:

--- a/toontown/suit/DistributedLawbotBoss.py
+++ b/toontown/suit/DistributedLawbotBoss.py
@@ -71,7 +71,7 @@ class DistributedLawbotBoss(DistributedBossCog.DistributedBossCog, FSM.FSM):
         self.reflectedMainDoor = None
         self.panFlashInterval = None
         self.panDamage = ToontownGlobals.LawbotBossDefensePanDamage
-        if base.config.GetBool('lawbot-boss-cheat', 0):
+        if ConfigVariableBool('lawbot-boss-cheat', 0).getValue():
             self.panDamage = 25
         self.evidenceHitSfx = None
         self.toonUpSfx = None
@@ -483,7 +483,7 @@ class DistributedLawbotBoss(DistributedBossCog.DistributedBossCog, FSM.FSM):
         colNode.setName('WitnessStand')
 
     def loadScale(self):
-        self.useProgrammerScale = base.config.GetBool('want-injustice-scale-debug', 0)
+        self.useProgrammerScale = ConfigVariableBool('want-injustice-scale-debug', 0).getValue()
         if self.useProgrammerScale:
             self.loadScaleOld()
         else:

--- a/toontown/suit/DistributedLawbotBossAI.py
+++ b/toontown/suit/DistributedLawbotBossAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.ai.AIBaseGlobal import *
 from direct.distributed.ClockDelta import *
 from toontown.suit import DistributedBossCogAI
@@ -274,7 +275,7 @@ class DistributedLawbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FSM
             weakenedValue = (
              (1, 1), (2, 2), (2, 2), (1, 1), (1, 1, 1, 1, 1))
             listVersion = list(SuitBuildingGlobals.SuitBuildingInfo)
-            if simbase.config.GetBool('lawbot-boss-cheat', 0):
+            if ConfigVariableBool('lawbot-boss-cheat', 0).getValue():
                 listVersion[13] = weakenedValue
                 SuitBuildingGlobals.SuitBuildingInfo = tuple(listVersion)
             return self.invokeSuitPlanner(13, 0)
@@ -492,7 +493,7 @@ class DistributedLawbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FSM
         jurorsOver = self.numToonJurorsSeated - ToontownGlobals.LawbotBossJurorsForBalancedScale
         dmgAdjust = jurorsOver * ToontownGlobals.LawbotBossDamagePerJuror
         self.b_setBossDamage(ToontownGlobals.LawbotBossInitialDamage + dmgAdjust, 0, 0)
-        if simbase.config.GetBool('lawbot-boss-cheat', 0):
+        if ConfigVariableBool('lawbot-boss-cheat', 0).getValue():
             self.b_setBossDamage(ToontownGlobals.LawbotBossMaxDamage - 1, 0, 0)
         self.battleThreeStart = globalClock.getFrameTime()
         for toonId in self.involvedToons:

--- a/toontown/suit/DistributedSellbotBoss.py
+++ b/toontown/suit/DistributedSellbotBoss.py
@@ -5,7 +5,6 @@ from toontown.battle.BattleProps import *
 from direct.distributed.ClockDelta import *
 from direct.showbase.PythonUtil import Functor
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.fsm import FSM
 from direct.fsm import ClassicFSM, State
 from direct.fsm import State
@@ -1158,7 +1157,7 @@ class DistributedSellbotBoss(DistributedBossCog.DistributedBossCog, FSM.FSM):
         taskMgr.remove(self.uniqueName('PieAdvice'))
 
     def __pieSplat(self, toon, pieCode):
-        if base.config.GetBool('easy-vp', 0):
+        if ConfigVariableBool('easy-vp', 0).getValue():
             if not self.dizzy:
                 pieCode = ToontownGlobals.PieCodeBossInsides
         if pieCode == ToontownGlobals.PieCodeBossInsides:

--- a/toontown/suit/DistributedSellbotBossAI.py
+++ b/toontown/suit/DistributedSellbotBossAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableInt
 from otp.ai.AIBaseGlobal import *
 from direct.distributed.ClockDelta import *
 from toontown.suit import DistributedBossCogAI
@@ -374,7 +375,7 @@ class DistributedSellbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
         for toonId in self.involvedToons:
             toon = self.air.doId2do.get(toonId)
             if toon:
-                configMax = simbase.config.GetInt('max-sos-cards', 16)
+                configMax = ConfigVariableInt('max-sos-cards', 16).getValue()
                 if configMax == 8:
                     maxNumCalls = 1
                 else:

--- a/toontown/suit/DistributedSuitAI.py
+++ b/toontown/suit/DistributedSuitAI.py
@@ -14,8 +14,8 @@ from toontown.hood import ZoneUtil
 import random
 
 class DistributedSuitAI(DistributedSuitBaseAI.DistributedSuitBaseAI):
-    SUIT_BUILDINGS = simbase.config.GetBool('want-suit-buildings', 1)
-    DEBUG_SUIT_POSITIONS = simbase.config.GetBool('debug-suit-positions', 0)
+    SUIT_BUILDINGS = ConfigVariableBool('want-suit-buildings', 1).getValue()
+    DEBUG_SUIT_POSITIONS = ConfigVariableBool('debug-suit-positions', 0).getValue()
     UPDATE_TIMESTAMP_INTERVAL = 180.0
     myId = 0
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedSuitAI')

--- a/toontown/suit/DistributedSuitBase.py
+++ b/toontown/suit/DistributedSuitBase.py
@@ -159,7 +159,7 @@ class DistributedSuitBase(DistributedAvatar.DistributedAvatar, Suit.Suit, SuitBa
             self.propInSound = base.loader.loadSfx('phase_5/audio/sfx/ENC_propeller_in.ogg')
         if self.propOutSound == None:
             self.propOutSound = base.loader.loadSfx('phase_5/audio/sfx/ENC_propeller_out.ogg')
-        if base.config.GetBool('want-new-cogs', 0):
+        if ConfigVariableBool('want-new-cogs', 0).getValue():
             head = self.find('**/to_head')
             if head.isEmpty():
                 head = self.find('**/joint_head')

--- a/toontown/suit/DistributedSuitPlannerAI.py
+++ b/toontown/suit/DistributedSuitPlannerAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool, ConfigVariableDouble, ConfigVariableInt, ConfigVariableString
 from panda3d.toontown import *
 from otp.ai.AIBaseGlobal import *
 from direct.distributed import DistributedObjectAI
@@ -18,9 +19,9 @@ from toontown.toonbase import ToontownGlobals
 import math, time, random
 
 class DistributedSuitPlannerAI(DistributedObjectAI.DistributedObjectAI, SuitPlannerBase.SuitPlannerBase):
-    CogdoPopFactor = config.GetFloat('cogdo-pop-factor', 1.5)
-    CogdoRatio = min(1.0, max(0.0, config.GetFloat('cogdo-ratio', 0.5)))
-    MinimumOfOne = config.GetBool('minimum-of-one-building', 0)
+    CogdoPopFactor = ConfigVariableDouble('cogdo-pop-factor', 1.5).getValue()
+    CogdoRatio = min(1.0, max(0.0, ConfigVariableDouble('cogdo-ratio', 0.5).getValue()))
+    MinimumOfOne = ConfigVariableBool('minimum-of-one-building', 0).getValue()
     SuitHoodInfo = [
      [
       2100, 5, 15, 0, 5, 20, 3, (1, 5, 10, 40, 60, 80), (25, 25, 25, 25), (1, 2, 3), []], [2200, 3, 10, 0, 5, 15, 3, (1, 5, 10, 40, 60, 80), (10, 70, 10, 10), (1, 2, 3), []], [2300, 3, 10, 0, 5, 15, 3, (1, 5, 10, 40, 60, 80), (10, 10, 40, 40), (1, 2, 3), []], [1100, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (90, 10, 0, 0), (2, 3, 4), []], [1200, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (0, 0, 90, 10), (3, 4, 5, 6), []], [1300, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (40, 40, 10, 10), (3, 4, 5, 6), []], [3100, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (90, 10, 0, 0), (5, 6, 7), []], [3200, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (10, 20, 30, 40), (5, 6, 7), []], [3300, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (5, 85, 5, 5), (7, 8, 9), []], [4100, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (0, 0, 50, 50), (2, 3, 4), []], [4200, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (0, 0, 90, 10), (3, 4, 5, 6), []], [4300, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (50, 50, 0, 0), (3, 4, 5, 6), []], [5100, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (0, 20, 10, 70), (2, 3, 4), []], [5200, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (10, 70, 0, 20), (3, 4, 5, 6), []], [5300, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (5, 5, 5, 85), (3, 4, 5, 6), []], [9100, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (25, 25, 25, 25), (6, 7, 8, 9), []], [9200, 1, 5, 0, 99, 100, 4, (1, 5, 10, 40, 60, 80), (5, 5, 85, 5), (6, 7, 8, 9), []], [11000, 3, 15, 0, 0, 0, 4, (1, 5, 10, 40, 60, 80), (0, 0, 0, 100), (4, 5, 6), []], [11200, 10, 20, 0, 0, 0, 4, (1, 5, 10, 40, 60, 80), (0, 0, 0, 100), (4, 5, 6), []], [12000, 10, 20, 0, 0, 0, 4, (1, 5, 10, 40, 60, 80), (0, 0, 100, 0), (7, 8, 9), []], [13000, 10, 20, 0, 0, 0, 4, (1, 5, 10, 40, 60, 80), (0, 100, 0, 0), (8, 9, 10), []]]
@@ -78,7 +79,7 @@ class DistributedSuitPlannerAI(DistributedObjectAI.DistributedObjectAI, SuitPlan
         TOTAL_BWEIGHT_PER_HEIGHT[3] += weight * heights[3]
         TOTAL_BWEIGHT_PER_HEIGHT[4] += weight * heights[4]
 
-    defaultSuitName = simbase.config.GetString('suit-type', 'random')
+    defaultSuitName = ConfigVariableString('suit-type', 'random').getValue()
     if defaultSuitName == 'random':
         defaultSuitName = None
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedSuitPlannerAI')
@@ -146,10 +147,10 @@ class DistributedSuitPlannerAI(DistributedObjectAI.DistributedObjectAI, SuitPlan
 
         self.dnaStore.resetBlockNumbers()
         self.initBuildingsAndPoints()
-        numSuits = simbase.config.GetInt('suit-count', -1)
+        numSuits = ConfigVariableInt('suit-count', -1).getValue()
         if numSuits >= 0:
             self.currDesired = numSuits
-        suitHood = simbase.config.GetInt('suits-only-in-hood', -1)
+        suitHood = ConfigVariableInt('suits-only-in-hood', -1).getValue()
         if suitHood >= 0:
             if self.SuitHoodInfo[self.hoodInfoIdx][self.SUIT_HOOD_INFO_ZONE] != suitHood:
                 self.currDesired = 0
@@ -1021,7 +1022,7 @@ class DistributedSuitPlannerAI(DistributedObjectAI.DistributedObjectAI, SuitPlan
                 toon.b_setBattleId(toonId)
         pos = self.battlePosDict[canonicalZoneId]
         interactivePropTrackBonus = -1
-        if simbase.config.GetBool('props-buff-battles', True) and canonicalZoneId in self.cellToGagBonusDict:
+        if ConfigVariableBool('props-buff-battles', True).getValue() and canonicalZoneId in self.cellToGagBonusDict:
             tentativeBonusTrack = self.cellToGagBonusDict[canonicalZoneId]
             trackToHolidayDict = {ToontownBattleGlobals.SQUIRT_TRACK: ToontownGlobals.HYDRANTS_BUFF_BATTLES, ToontownBattleGlobals.THROW_TRACK: ToontownGlobals.MAILBOXES_BUFF_BATTLES, ToontownBattleGlobals.HEAL_TRACK: ToontownGlobals.TRASHCANS_BUFF_BATTLES}
             if tentativeBonusTrack in trackToHolidayDict:
@@ -1055,7 +1056,7 @@ class DistributedSuitPlannerAI(DistributedObjectAI.DistributedObjectAI, SuitPlan
         if len(battle.suits) >= 4:
             return 0
         if battle:
-            if simbase.config.GetBool('suits-always-join', 0):
+            if ConfigVariableBool('suits-always-join', 0).getValue():
                 return 1
             jChanceList = self.SuitHoodInfo[self.hoodInfoIdx][self.SUIT_HOOD_INFO_JCHANCE]
             ratioIdx = len(battle.toons) - battle.numSuitsEver + 2

--- a/toontown/toon/DistributedNPCPetclerk.py
+++ b/toontown/toon/DistributedNPCPetclerk.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from .DistributedNPCToonBase import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from . import NPCToons
 from direct.task.Task import Task
 from toontown.toonbase import TTLocalizer
@@ -173,7 +172,7 @@ class DistributedNPCPetclerk(DistributedNPCToonBase):
         return
 
     def __handlePetAdopted(self, whichPet, nameIndex):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ADOPTADOOLE: Adopt a doodle.')
         base.cr.removePetFromFriendsMap()
         self.ignore(self.eventDict['petAdopted'])

--- a/toontown/toon/DistributedNPCTailorAI.py
+++ b/toontown/toon/DistributedNPCTailorAI.py
@@ -7,8 +7,8 @@ from toontown.ai import DatabaseObject
 from toontown.estate import ClosetGlobals
 
 class DistributedNPCTailorAI(DistributedNPCToonBaseAI):
-    freeClothes = simbase.config.GetBool('free-clothes', 0)
-    housingEnabled = simbase.config.GetBool('want-housing', 1)
+    freeClothes = ConfigVariableBool('free-clothes', 0).getValue()
+    housingEnabled = ConfigVariableBool('want-housing', 1).getValue()
 
     def __init__(self, air, npcId):
         DistributedNPCToonBaseAI.__init__(self, air, npcId)

--- a/toontown/toon/DistributedNPCToonAI.py
+++ b/toontown/toon/DistributedNPCToonAI.py
@@ -5,7 +5,7 @@ from .DistributedNPCToonBaseAI import *
 from toontown.quest import Quests
 
 class DistributedNPCToonAI(DistributedNPCToonBaseAI):
-    FourthGagVelvetRopeBan = config.GetBool('want-ban-fourth-gag-velvet-rope', 0)
+    FourthGagVelvetRopeBan = ConfigVariableBool('want-ban-fourth-gag-velvet-rope', 0).getValue()
 
     def __init__(self, air, npcId, questCallback = None, hq = 0):
         DistributedNPCToonBaseAI.__init__(self, air, npcId, questCallback)

--- a/toontown/toon/DistributedToon.py
+++ b/toontown/toon/DistributedToon.py
@@ -472,7 +472,7 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
         if fromAV in self.ignoreList:
             self.d_setWhisperIgnored(fromAV)
             return
-        if base.config.GetBool('want-sleep-reply-on-regular-chat', 0):
+        if ConfigVariableBool('want-sleep-reply-on-regular-chat', 0).getValue():
             if base.localAvatar.sleepFlag == 1:
                 self.sendUpdate('setSleepAutoReply', [base.localAvatar.doId], fromAV)
         newText, scrubbed = self.scrubTalk(chat, mods)
@@ -493,7 +493,7 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
         if fromAV in self.ignoreList:
             self.d_setWhisperIgnored(fromAV)
             return
-        if base.config.GetBool('ignore-whispers', 0):
+        if ConfigVariableBool('ignore-whispers', 0).getValue():
             return
         if base.localAvatar.sleepFlag == 1:
             if not base.cr.identifyAvatar(fromAV) == base.localAvatar:
@@ -840,7 +840,7 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
             ts = 0.0
         else:
             ts = globalClockDelta.localElapsedTime(timestamp)
-        if base.config.GetBool('check-invalid-anims', True):
+        if ConfigVariableBool('check-invalid-anims', True).getValue():
             if animMultiplier > 1.0 and animName in ['neutral']:
                 animMultiplier = 1.0
         if self.animFSM.getStateNamed(animName):
@@ -2108,7 +2108,7 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
     def setNametagStyle(self, nametagStyle):
         if hasattr(self, 'gmToonLockStyle') and self.gmToonLockStyle:
             return
-        if base.config.GetBool('want-nametag-avids', 0):
+        if ConfigVariableBool('want-nametag-avids', 0).getValue():
             nametagStyle = 0
         self.nametagStyle = nametagStyle
         self.setDisplayName(self.getName())

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -67,8 +67,8 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
      ToontownGlobals.FT_Leg: (CogDisguiseGlobals.leftLegIndex, CogDisguiseGlobals.rightLegIndex),
      ToontownGlobals.FT_Arm: (CogDisguiseGlobals.leftArmIndex, CogDisguiseGlobals.rightArmIndex),
      ToontownGlobals.FT_Torso: (CogDisguiseGlobals.torsoIndex,)}
-    WantTpTrack = simbase.config.GetBool('want-tptrack', False)
-    WantOldGMNameBan = simbase.config.GetBool('want-old-gm-name-ban', 1)
+    WantTpTrack = ConfigVariableBool('want-tptrack', False).getValue()
+    WantOldGMNameBan = ConfigVariableBool('want-old-gm-name-ban', 1).getValue()
 
     def __init__(self, air):
         DistributedPlayerAI.DistributedPlayerAI.__init__(self, air)
@@ -339,13 +339,13 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         if self.isPlayerControlled() and self.WantTpTrack:
             messenger.send(self.staticGetLogicalZoneChangeAllEvent(), [newZoneId, oldZoneId, self])
         if self.cogIndex != -1 and not ToontownAccessAI.canWearSuit(self.doId, newZoneId):
-            if simbase.config.GetBool('cogsuit-hack-prevent', False):
+            if ConfigVariableBool('cogsuit-hack-prevent', False).getValue():
                 self.b_setCogIndex(-1)
             if not simbase.air.cogSuitMessageSent:
                 self.notify.warning('%s handleLogicalZoneChange as a suit: %s' % (self.doId, self.cogIndex))
                 self.air.writeServerEvent('suspicious', self.doId, 'Toon wearing a cog suit with index: %s in a zone they are not allowed to in. Zone: %s' % (self.cogIndex, newZoneId))
                 simbase.air.cogSuitMessageSent = True
-                if simbase.config.GetBool('want-ban-wrong-suit-place', False):
+                if ConfigVariableBool('want-ban-wrong-suit-place', False).getValue():
                     commentStr = 'Toon %s wearing a suit in a zone they are not allowed to in. Zone: %s' % (self.doId, newZoneId)
                     dislId = self.DISLid
                     simbase.air.banManager.ban(self.doId, dislId, commentStr)
@@ -389,7 +389,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
                  textureIdx,
                  colorIdx))
                 return 0
-            if not simbase.config.GetBool('want-check-accessory-sanity', False):
+            if not ConfigVariableBool('want-check-accessory-sanity', False).getValue():
                 return 1
             accessoryItem = CatalogAccessoryItem.CatalogAccessoryItem(accessoryItemId)
             result = self.air.catalogManager.isItemReleased(accessoryItem)
@@ -480,7 +480,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
 
     def setDNAString(self, string):
         self.dna.makeFromNetString(string)
-        if simbase.config.GetBool('adjust-dna', True) and self.verifyDNA() == False:
+        if ConfigVariableBool('adjust-dna', True).getValue() and self.verifyDNA() == False:
             logStr = 'AvatarHackWarning! invalid dna colors for %s old: %s new: %s' % (self.doId, str(ToonDNA.ToonDNA(string).asTuple()), str(self.dna.asTuple()))
             self.notify.warning(logStr)
             self.air.writeServerEvent('suspicious', self.doId, logStr)
@@ -624,7 +624,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         if max & 32768:
             self.b_setSosPageFlag(1)
             max &= 32767
-        configMax = simbase.config.GetInt('max-sos-cards', 16)
+        configMax = ConfigVariableInt('max-sos-cards', 16).getValue()
         if configMax != max:
             if self.sosPageFlag == 0:
                 self.b_setMaxNPCFriends(configMax)
@@ -1158,7 +1158,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
     def setAnimState(self, animName, animMultiplier, timestamp = 0):
         if animName not in ToontownGlobals.ToonAnimStates:
             desc = 'tried to set invalid animState: %s' % (animName,)
-            if config.GetBool('want-ban-animstate', 1):
+            if ConfigVariableBool('want-ban-animstate', 1).getValue():
                 simbase.air.banManager.ban(self.doId, self.DISLid, desc)
             else:
                 self.air.writeServerEvent('suspicious', self.doId, desc)
@@ -1427,7 +1427,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
 
     def b_setCogIndex(self, index):
         self.setCogIndex(index)
-        if simbase.config.GetBool('cogsuit-hack-prevent', False):
+        if ConfigVariableBool('cogsuit-hack-prevent', False).getValue():
             self.d_setCogIndex(self.cogIndex)
         else:
             self.d_setCogIndex(index)
@@ -1436,7 +1436,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         if index != -1 and not ToontownAccessAI.canWearSuit(self.doId, self.zoneId):
             if not simbase.air.cogSuitMessageSent:
                 self.notify.warning('%s setCogIndex invalid: %s' % (self.doId, index))
-                if simbase.config.GetBool('want-ban-wrong-suit-place', False):
+                if ConfigVariableBool('want-ban-wrong-suit-place', False).getValue():
                     commentStr = 'Toon %s trying to set cog index to %s in Zone: %s' % (self.doId, index, self.zoneId)
                     simbase.air.banManager.ban(self.doId, self.DISLid, commentStr)
         else:
@@ -1925,7 +1925,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
     def checkTeleportAccess(self, zoneId):
         if zoneId not in self.getTeleportAccess():
             simbase.air.writeServerEvent('suspicious', self.doId, 'Toon teleporting to zone %s they do not have access to.' % zoneId)
-            if simbase.config.GetBool('want-ban-teleport', False):
+            if ConfigVariableBool('want-ban-teleport', False).getValue():
                 commentStr = 'Toon %s teleporting to a zone %s they do not have access to' % (self.doId, zoneId)
                 simbase.air.banManager.ban(self.doId, self.DISLid, commentStr)
 
@@ -2443,7 +2443,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
             money = 0
             commentStr = 'User %s has negative money %s' % (self.doId, money)
             dislId = self.DISLid
-            if simbase.config.GetBool('want-ban-negative-money', False):
+            if ConfigVariableBool('want-ban-negative-money', False).getValue():
                 simbase.air.banManager.ban(self.doId, dislId, commentStr)
         self.money = money
 
@@ -3663,14 +3663,14 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         if strSearch.search(eventName, 0, 100):
             self.air.district.recordSuspiciousEventData(len(eventStr))
         self.air.writeServerEvent('suspicious', self.doId, eventStr)
-        if simbase.config.GetBool('want-ban-setSCSinging', True):
+        if ConfigVariableBool('want-ban-setSCSinging', True).getValue():
             if 'invalid msgIndex in setSCSinging:' in eventName:
                 if senderId == self.doId:
                     commentStr = 'Toon %s trying to call setSCSinging' % self.doId
                     simbase.air.banManager.ban(self.doId, self.DISLid, commentStr)
                 else:
                     self.notify.warning('logSuspiciousEvent event=%s senderId=%s != self.doId=%s' % (eventName, senderId, self.doId))
-        if simbase.config.GetBool('want-ban-setAnimState', True):
+        if ConfigVariableBool('want-ban-setAnimState', True).getValue():
             if eventName.startswith('setAnimState: '):
                 if senderId == self.doId:
                     commentStr = 'Toon %s trying to call setAnimState' % self.doId
@@ -3782,7 +3782,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         self.sendUpdate('setAccess', [access])
 
     def setAccess(self, access):
-        paidStatus = simbase.config.GetString('force-paid-status', 'none')
+        paidStatus = ConfigVariableString('force-paid-status', 'none').getValue()
         if paidStatus == 'unpaid':
             access = 1
         self.notify.debug('Setting Access %s' % access)
@@ -4108,7 +4108,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
 
     def _checkOldGMName(self):
         if '$' in set(self.name):
-            if config.GetBool('want-ban-old-gm-name', 0):
+            if ConfigVariableBool('want-ban-old-gm-name', 0).getValue():
                 self.ban('invalid name: %s' % self.name)
             else:
                 self.air.writeServerEvent('suspicious', self.doId, '$ found in toon name')

--- a/toontown/toon/InventoryBase.py
+++ b/toontown/toon/InventoryBase.py
@@ -209,7 +209,7 @@ class InventoryBase(DirectObject.DirectObject):
                 if tempInv[track][level] > 0 and not self.toon.hasTrackAccess(track):
                     commentStr = "Player %s trying to purchase gag they don't have track access to. track: %s level: %s" % (self.toon.doId, track, level)
                     dislId = self.toon.DISLid
-                    if simbase.config.GetBool('want-ban-gagtrack', False):
+                    if ConfigVariableBool('want-ban-gagtrack', False).getValue():
                         simbase.air.banManager.ban(self.toon.doId, dislId, commentStr)
                     return 0
                 if level > LAST_REGULAR_GAG_LEVEL and tempInv[track][level] > self.inventory[track][level] or allowUber:

--- a/toontown/toon/InventoryNew.py
+++ b/toontown/toon/InventoryNew.py
@@ -47,7 +47,7 @@ class InventoryNew(InventoryBase.InventoryBase, DirectFrame):
         self.gagTutMode = 0
         self.showSuperGags = ShowSuperGags
         self.clickSuperGags = 1
-        self.propAndOrganicBonusStack = base.config.GetBool('prop-and-organic-bonus-stack', 0)
+        self.propAndOrganicBonusStack = ConfigVariableBool('prop-and-organic-bonus-stack', 0).getValue()
         self.propBonusIval = Parallel()
         self.activateMode = 'book'
         self.load()

--- a/toontown/toon/LocalToon.py
+++ b/toontown/toon/LocalToon.py
@@ -54,7 +54,7 @@ from . import Toon
 from . import LaffMeter
 from toontown.quest import QuestMap
 from toontown.toon.DistributedNPCToonBase import DistributedNPCToonBase
-WantNewsPage = base.config.GetBool('want-news-page', ToontownGlobals.DefaultWantNewsPageSetting)
+WantNewsPage = ConfigVariableBool('want-news-page', ToontownGlobals.DefaultWantNewsPageSetting).getValue()
 from toontown.toontowngui import NewsPageButtonManager
 if WantNewsPage:
     from toontown.shtiker import NewsPage
@@ -65,8 +65,8 @@ if (__debug__):
 
 class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
     neverDisable = 1
-    piePowerSpeed = base.config.GetDouble('pie-power-speed', 0.2)
-    piePowerExponent = base.config.GetDouble('pie-power-exponent', 0.75)
+    piePowerSpeed = ConfigVariableDouble('pie-power-speed', 0.2).getValue()
+    piePowerExponent = ConfigVariableDouble('pie-power-exponent', 0.75).getValue()
 
     def __init__(self, cr):
         try:
@@ -122,9 +122,9 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
             self.tossPieStart = None
             self.__presentingPie = 0
             self.__pieSequence = 0
-            self.wantBattles = base.config.GetBool('want-battles', 1)
-            self.seeGhosts = base.config.GetBool('see-ghosts', 0)
-            wantNameTagAvIds = base.config.GetBool('want-nametag-avids', 0)
+            self.wantBattles = ConfigVariableBool('want-battles', 1).getValue()
+            self.seeGhosts = ConfigVariableBool('see-ghosts', 0).getValue()
+            wantNameTagAvIds = ConfigVariableBool('want-nametag-avids', 0).getValue()
             if wantNameTagAvIds:
                 messenger.send('nameTagShowAvId', [])
                 base.idTags = 1
@@ -135,7 +135,7 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
             self.ticker = 0
             self.glitchOkay = 1
             self.tempGreySpacing = 0
-            self.wantStatePrint = base.config.GetBool('want-statePrint', 0)
+            self.wantStatePrint = ConfigVariableBool('want-statePrint', 0).getValue()
             self.__gardeningGui = None
             self.__gardeningGuiFake = None
             self.__shovelButton = None
@@ -163,8 +163,8 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
             if not hasattr(base.cr, 'lastLoggedIn'):
                 base.cr.lastLoggedIn = self.cr.toontownTimeManager.convertStrToToontownTime('')
             self.setLastTimeReadNews(base.cr.lastLoggedIn)
-            self.acceptingNewFriends = base.settings.getSetting('accepting-new-friends', True) and base.config.GetBool('accepting-new-friends-default', True)
-            self.acceptingNonFriendWhispers = base.settings.getSetting('accepting-non-friend-whispers', True) and base.config.GetBool('accepting-non-friend-whispers-default', True)
+            self.acceptingNewFriends = base.settings.getSetting('accepting-new-friends', True) and ConfigVariableBool('accepting-new-friends-default', True).getValue()
+            self.acceptingNonFriendWhispers = base.settings.getSetting('accepting-non-friend-whispers', True) and ConfigVariableBool('accepting-non-friend-whispers-default', True).getValue()
             self.physControls.event.addAgainPattern('again%in')
             self.oldPos = None
             self.questMap = None
@@ -346,7 +346,7 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
         self.suitPage = SuitPage.SuitPage()
         self.suitPage.load()
         self.book.addPage(self.suitPage, pageName=TTLocalizer.SuitPageTitle)
-        if base.config.GetBool('want-photo-album', 0):
+        if ConfigVariableBool('want-photo-album', 0).getValue():
             self.photoAlbumPage = PhotoAlbumPage.PhotoAlbumPage()
             self.photoAlbumPage.load()
             self.book.addPage(self.photoAlbumPage, pageName=TTLocalizer.PhotoPageTitle)
@@ -474,11 +474,11 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
         self.notify.debug('Setting GM State: %s in LocalToon' % state)
         DistributedToon.DistributedToon.setAsGM(self, state)
         if self.gmState:
-            if base.config.GetString('gm-nametag-string', '') != '':
-                self.gmNameTagString = base.config.GetString('gm-nametag-string')
-            if base.config.GetString('gm-nametag-color', '') != '':
-                self.gmNameTagColor = base.config.GetString('gm-nametag-color')
-            if base.config.GetInt('gm-nametag-enabled', 0):
+            if ConfigVariableString('gm-nametag-string', '').getValue() != '':
+                self.gmNameTagString = ConfigVariableString('gm-nametag-string').getValue()
+            if ConfigVariableString('gm-nametag-color', '').getValue() != '':
+                self.gmNameTagColor = ConfigVariableString('gm-nametag-color').getValue()
+            if ConfigVariableInt('gm-nametag-enabled', 0).getValue():
                 self.gmNameTagEnabled = 1
             self.d_updateGMNameTag()
 
@@ -1052,14 +1052,14 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
         if self.__catalogNotifyDialog:
             self.__catalogNotifyDialog.cleanup()
             self.__catalogNotifyDialog = None
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: VISITESTATE: Visit estate')
         place.goHomeNow(self.lastHood)
         return
 
     def __startMoveFurniture(self):
         self.oldPos = self.getPos()
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: ESTATE:  Furniture Placement')
         if self.cr.furnitureManager != None:
             self.cr.furnitureManager.d_suggestDirector(self.doId)
@@ -1829,7 +1829,7 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
 
     def getAccountDays(self):
         days = 0
-        defaultDays = base.cr.config.GetInt('account-days', -1)
+        defaultDays = ConfigVariableInt('account-days', -1).getValue()
         if defaultDays >= 0:
             days = defaultDays
         elif hasattr(base.cr, 'accountDays'):
@@ -1884,7 +1884,7 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
         return self.lastTimeReadNews
 
     def cheatCogdoMazeGame(self, kindOfCheat = 0):
-        if base.config.GetBool('allow-cogdo-maze-suit-hit-cheat'):
+        if ConfigVariableBool('allow-cogdo-maze-suit-hit-cheat').getValue():
             maze = base.cr.doFind('DistCogdoMazeGame')
             if maze:
                 if kindOfCheat == 0:
@@ -1914,7 +1914,7 @@ class LocalToon(DistributedToon.DistributedToon, LocalAvatar.LocalAvatar):
         localAvatar.d_teleportResponse(avId, available, shardId, hoodId, zoneId, sendToId)
 
     def d_teleportResponse(self, avId, available, shardId, hoodId, zoneId, sendToId = None):
-        if base.config.GetBool('want-tptrack', False):
+        if ConfigVariableBool('want-tptrack', False).getValue():
             if available == 1:
                 self.notify.debug('sending teleportResponseToAI')
                 self.sendUpdate('teleportResponseToAI', [avId,

--- a/toontown/toon/NPCToons.py
+++ b/toontown/toon/NPCToons.py
@@ -11481,10 +11481,6 @@ NPCToonDict = {20000: (-1,
         'm',
         0,
         NPC_REGULAR)}
-try:
-    config = simbase.config
-except:
-    config = base.config
 
 if ConfigVariableBool('want-new-toonhall', 1).value:
     NPCToonDict[2001] = (2513,

--- a/toontown/toon/TTEmote.py
+++ b/toontown/toon/TTEmote.py
@@ -340,7 +340,7 @@ def stopSinginAnim(toon):
 
 
 def singNote1(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'g1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -350,7 +350,7 @@ def singNote1(toon, volume = 1):
 
 
 def singNote2(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'a1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -360,7 +360,7 @@ def singNote2(toon, volume = 1):
 
 
 def singNote3(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'b1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -370,7 +370,7 @@ def singNote3(toon, volume = 1):
 
 
 def singNote4(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'c1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -380,7 +380,7 @@ def singNote4(toon, volume = 1):
 
 
 def singNote5(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'd1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -390,7 +390,7 @@ def singNote5(toon, volume = 1):
 
 
 def singNote6(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'e1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -400,7 +400,7 @@ def singNote6(toon, volume = 1):
 
 
 def singNote7(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'f1')
         elif toon.style.getTorsoSize() == 'medium':
@@ -410,7 +410,7 @@ def singNote7(toon, volume = 1):
 
 
 def singNote8(toon, volume = 1):
-    if base.config.GetBool('want-octaves', True):
+    if ConfigVariableBool('want-octaves', True).getValue():
         if toon.style.getTorsoSize() == 'short':
             return getSingingNote(toon, 'g2')
         elif toon.style.getTorsoSize() == 'medium':

--- a/toontown/toon/ToonAvatarPanel.py
+++ b/toontown/toon/ToonAvatarPanel.py
@@ -1,6 +1,5 @@
 from panda3d.core import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.showbase import DirectObject
 from . import ToonHead
 from toontown.friends import FriendHandle
@@ -522,7 +521,7 @@ class ToonAvatarPanel(AvatarPanelBase.AvatarPanelBase):
                         self.groupButton['command'] = self.handleInvite
                         self.groupButton['image'] = self.inviteImageList
                         self.groupButton['state'] = DGG.NORMAL
-                    if base.config.GetBool('want-boarding-groups', 1):
+                    if ConfigVariableBool('want-boarding-groups', 1).getValue():
                         base.setCellsAvailable([base.rightCells[0]], 0)
                         self.groupFrame.show()
         return

--- a/toontown/toonbase/ToontownAccessAI.py
+++ b/toontown/toonbase/ToontownAccessAI.py
@@ -1,3 +1,4 @@
+from panda3d.core import ConfigVariableBool
 from otp.otpbase import OTPGlobals
 from otp.ai import BanManagerAI
 from toontown.toonbase import ToontownGlobals
@@ -9,7 +10,7 @@ def canAccess(avatarId, zoneId, function = ''):
         if cmp(function, 'DistributedBoardingPartyAI.checkBoard') == 0:
             return False
         simbase.air.writeServerEvent('suspicious', avatarId, 'User with rights: %s requesting enter for paid access content without proper rights in zone %s from %s' % (avatar.getGameAccess(), zoneId, function))
-        if simbase.config.GetBool('want-ban-ispaid', True):
+        if ConfigVariableBool('want-ban-ispaid', True).getValue():
             commentStr = 'User with rights: %s tried to gain access zone %s from function %s, an area they were not allowed to using TTInjector Hack' % (avatar.getGameAccess(), zoneId, function)
             dislId = avatar.DISLid
             simbase.air.banManager.ban(avatarId, dislId, commentStr)

--- a/toontown/toontowngui/TeaserPanel.py
+++ b/toontown/toontowngui/TeaserPanel.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from direct.gui.DirectGui import *
 from direct.gui import DirectGuiGlobals
-from panda3d.core import *
 from direct.directnotify import DirectNotifyGlobal
 from . import TTDialog
 from toontown.toonbase import TTLocalizer
@@ -129,7 +128,7 @@ class TeaserPanel(DirectObject):
         self.dialog.setPos(0, 0, 0.75)
         self.browser.reparentTo(self.dialog)
         base.transitions.fadeScreen(0.5)
-        if base.config.GetBool('want-teaser-scroll-keys', 0):
+        if ConfigVariableBool('want-teaser-scroll-keys', 0).getValue():
             self.accept('arrow_right', self.showNextPage)
             self.accept('arrow_left', self.showPrevPage)
         self.accept('stoppedAsleep', self.__handleDone)

--- a/toontown/town/TownBattleSOSPanel.py
+++ b/toontown/town/TownBattleSOSPanel.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from toontown.toonbase.ToontownGlobals import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.showbase import DirectObject
 from direct.directnotify import DirectNotifyGlobal
 from direct.fsm import StateData
@@ -160,7 +159,7 @@ class TownBattleSOSPanel(DirectFrame, StateData.StateData):
 
     def __updateScrollList(self):
         newFriends = []
-        battlePets = base.config.GetBool('want-pets-in-battle', 1)
+        battlePets = ConfigVariableBool('want-pets-in-battle', 1).getValue()
         if base.wantPets and battlePets == 1 and base.localAvatar.hasPet():
             newFriends.append((base.localAvatar.getPetId(), 0))
         if not self.bldg or self.factoryToonIdList is not None:

--- a/toontown/trolley/Trolley.py
+++ b/toontown/trolley/Trolley.py
@@ -1,7 +1,6 @@
 from panda3d.core import *
 from toontown.toonbase.ToonBaseGlobal import *
 from direct.gui.DirectGui import *
-from panda3d.core import *
 from direct.interval.IntervalGlobal import *
 from direct.fsm import ClassicFSM, State
 from direct.fsm import State
@@ -156,7 +155,7 @@ class Trolley(StateData.StateData):
         return None
 
     def enterBoarded(self):
-        if base.config.GetBool('want-qa-regression', 0):
+        if ConfigVariableBool('want-qa-regression', 0).getValue():
             self.notify.info('QA-REGRESSION: RIDETHETROLLEY: Ride the Trolley')
         self.enableExitButton()
         return None


### PR DESCRIPTION
This pull request removes the deprecated DConfig module from the codebase, replacing it with the modern ConfigVariable implementation.

For the most part, this replaces lines such as `config.GetBool('some-var', 0)` with the equivalent behavior of `ConfigVariableBool('some-var', 0).getValue()`. However, some of the more popularly-used config variables could be moved to a file such as ToontownGlobals now that they are ConfigVariables, if desired.

I also went through each changed file and explicitly imported the names (unless a `from panda3d.core import *` statement already existed), even if the names exist in the module from some other star import.