### PR TITLE
Return latestIssueStr from DistributedInGameNewsMgr.getLatestIssueStr

### DIFF
--- a/toontown/uberdog/DistributedInGameNewsMgr.py
+++ b/toontown/uberdog/DistributedInGameNewsMgr.py
@@ -34,7 +34,7 @@ class DistributedInGameNewsMgr(DistributedObject):
         self.notify.info('latestIssue=%s' % self.latestIssue)
 
     def getLatestIssueStr(self):
-        pass
+        return self.latestIssueStr
 
     def getLatestIssue(self):
         return self.latestIssue


### PR DESCRIPTION
`getLatestIssueStr` has a bare `pass` body, so it returns `None` instead of `self.latestIssueStr`. The sibling `getLatestIssue` returns its value, and the setter `setLatestIssueStr` populates the attribute, so the intent here is clear.

No callers in the current tree, so no behavior change in production paths; this just stops the method from being a foot-gun for anyone who needs the raw timestamp string later.

Fixes #132