### PR TITLE
Guard DistributedInGameNewsMgr.getLatestIssue against None

### DIFF
--- a/toontown/shtiker/DirectNewsFrame.py
+++ b/toontown/shtiker/DirectNewsFrame.py
@@ -168,7 +168,8 @@ class DirectNewsFrame(DirectObject.DirectObject):
         self.mainFrame = DirectFrame(parent=self.backFrame, frameSize=self.FrameDimensions, frameColor=(1, 0, 0, 1))
 
     def activate(self):
-        if hasattr(self, 'createdTime') and self.createdTime < base.cr.inGameNewsMgr.getLatestIssue() and self.NewsOverHttp and not self.redownloadingNews:
+        latestIssue = base.cr.inGameNewsMgr.getLatestIssue()
+        if hasattr(self, 'createdTime') and latestIssue is not None and self.createdTime < latestIssue and self.NewsOverHttp and not self.redownloadingNews:
             self.redownloadNews()
         else:
             self.addDownloadingTextTask()
@@ -361,8 +362,9 @@ class DirectNewsFrame(DirectObject.DirectObject):
             print('%s\t%s\t%s' % (filename, size, date), file=file)
 
     def handleNewIssueOut(self):
-        if hasattr(self, 'createdTime') and base.cr.inGameNewsMgr.getLatestIssue() < self.createdTime:
-            self.createdTime = base.cr.inGameNewsMgr.getLatestIssue()
+        latestIssue = base.cr.inGameNewsMgr.getLatestIssue()
+        if hasattr(self, 'createdTime') and latestIssue is not None and latestIssue < self.createdTime:
+            self.createdTime = latestIssue
         elif self.NewsOverHttp and not self.redownloadingNews:
             if not self.active:
                 self.redownloadNews()

--- a/toontown/toontowngui/NewsPageButtonManager.py
+++ b/toontown/toontowngui/NewsPageButtonManager.py
@@ -113,7 +113,11 @@ class NewsPageButtonManager(FSM.FSM):
         self.__blinkIval.pause()
 
     def isNewIssueButtonShown(self):
-        if localAvatar.getLastTimeReadNews() < base.cr.inGameNewsMgr.getLatestIssue():
+        latestIssue = base.cr.inGameNewsMgr.getLatestIssue()
+        lastRead = localAvatar.getLastTimeReadNews()
+        if latestIssue is None or lastRead is None:
+            return False
+        if lastRead < latestIssue:
             return True
         return False
 
@@ -126,7 +130,9 @@ class NewsPageButtonManager(FSM.FSM):
     def enterNormalWalk(self):
         if not self.buttonsLoaded:
             return
-        if localAvatar.getLastTimeReadNews() < base.cr.inGameNewsMgr.getLatestIssue():
+        latestIssue = base.cr.inGameNewsMgr.getLatestIssue()
+        lastRead = localAvatar.getLastTimeReadNews()
+        if latestIssue is not None and lastRead is not None and lastRead < latestIssue:
             self.__showNewIssueButton()
             self.__blinkIval.resume()
         else:

--- a/toontown/uberdog/DistributedInGameNewsMgr.py
+++ b/toontown/uberdog/DistributedInGameNewsMgr.py
@@ -13,6 +13,8 @@ class DistributedInGameNewsMgr(DistributedObject):
     def __init__(self, cr):
         DistributedObject.__init__(self, cr)
         base.cr.inGameNewsMgr = self
+        self.latestIssueStr = ''
+        self.latestIssue = None
 
     def delete(self):
         DistributedObject.delete(self)


### PR DESCRIPTION
Partial fix for #25.

`DistributedInGameNewsMgr.__init__` never sets `self.latestIssue` or `self.latestIssueStr`. Normally the required-broadcast DC field populates them on `generate()`, but there's a window between the client object being created and that field arriving where `getLatestIssue()` raises `AttributeError`, and the four callers in `NewsPageButtonManager` and `DirectNewsFrame` crash comparing a `datetime` against `None`.

I init both attributes in `__init__` (`latestIssue=None`, `latestIssueStr=''`) so the getter returns `None` instead of raising, and made each caller treat `None` as "no new issue, do nothing". `setLatestIssueStr` still broadcasts `newIssueOut`, which re-triggers `showAppropriateButton`, so the UI catches up once the data lands.

Marking it partial rather than closing #25: the reporter's trace came through a modified `ToontownTimeManager` returning `None` from a time converter, which I can't reproduce against upstream, but the uninitialized attribute and the four unguarded comparisons are a real latent crash regardless and are where their stack bottomed out. Checked the four guarded branches against mocked `None` and real datetimes both ways and they all behave.
