### PR TITLE
Document Python dependency install, clearer error if pytz is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ $ pip install panda3d-1.11.0-cp39-cp39-macosx_10_9_x86_64.whl
 ## Linux (Building your own)
 If you use Linux, or are interested in building Panda3D yourself, head on over to [our Panda3D fork](https://github.com/open-toontown/panda3d) and read the "Building Panda3D" section on the README file there.
 
+# Python Dependencies
+Install the packages listed in `requirements.txt` using the **Panda3D-bundled Python**, which is the interpreter the start scripts run under (the path is stored in the `PPYTHON_PATH` file in the repository root). On Windows that looks like:
+```cmd
+"C:\Panda3D-1.11.0-x64\python\ppython.exe" -m pip install -r requirements.txt
+```
+On macOS or Linux, use the same Python 3.9 you installed the Panda3D wheel into, e.g. `python3.9 -m pip install -r requirements.txt`.
+
+Skipping this step causes the UberDOG and AI servers to fail at startup with `ModuleNotFoundError: No module named 'pytz'`.
+
 # Starting the Server and Game
 To start the server and run the game locally, go to your platform directory (`win32` for Windows, `darwin` for Mac and `linux` for Linux), and make sure you start the following scripts in order:
 

--- a/toontown/parties/ToontownTimeManager.py
+++ b/toontown/parties/ToontownTimeManager.py
@@ -1,6 +1,15 @@
+import sys
 import time
 from datetime import datetime, timedelta
-import pytz
+try:
+    import pytz
+except ImportError:
+    raise ImportError(
+        "pytz is not installed for this Python interpreter (%s). "
+        "Install the project's Python dependencies first: "
+        "%s -m pip install -r requirements.txt"
+        % (sys.executable, sys.executable)
+    ) from None
 from direct.directnotify import DirectNotifyGlobal
 from toontown.toonbase import TTLocalizer
 


### PR DESCRIPTION
Three reports (#26, #58, #122) of the UberDOG/AI servers crashing on a fresh install all bottom out on `ModuleNotFoundError: No module named 'pytz'`. The Panda3D installer ships its own Python and the start scripts use it, but the README only covers installing Panda3D, not the `requirements.txt` packages, so unless you know to run pip against the Panda3D-bundled Python the first UberDOG boot dies on `import pytz` in `ToontownTimeManager.py`.

Adds a 'Python Dependencies' section to the README with the exact pip command for the bundled Python (Windows) and 3.9 (macOS/Linux), and calls out the pytz symptom so people who google it land here. Also wraps the `import pytz` in a try/except that re-raises with `sys.executable` and the pip command, so if you skip the README the first stack trace tells you exactly what to run.

Verified the new error path by importing the module from a Python without pytz, the wrapped `ImportError` fires with the interpreter path as expected.

Closes #26
Closes #58
Closes #122
