### PR TITLE
Display typed open-chat locally so the sender sees their own bubble

### DIFF
--- a/otp/chat/TalkAssistant.py
+++ b/otp/chat/TalkAssistant.py
@@ -630,6 +630,7 @@ class TalkAssistant(DirectObject.DirectObject):
              message,
              [],
              0])
+            base.localAvatar.setChatAbsolute(message, chatFlags)
             messenger.send('chatUpdate', [message, chatFlags])
         return error
 


### PR DESCRIPTION
Fixes #31.

Typed chat bubbles show up over everyone else's toon but not the sender's own. Speedchat works fine for the sender.

The difference is how the two paths broadcast. Speedchat uses the standard broadcast+local idiom: `setSC` runs locally (displaying the bubble), then `d_setSC` sends the DC update. Typed chat (`TalkAssistant.sendOpenTalk`) only calls `sendUpdate("setTalk", ...)`, which broadcasts through the AI and never echoes back to the originator. `DistributedToon.setTalk` — the only call site for `displayTalk` — never runs for the sender.

Fix mirrors the speedchat pattern: call `setChatAbsolute(message, chatFlags)` locally right after `sendUpdate`. Same call `setSC` makes for sender-side display, same `chatFlags` semantics (`CFSpeech | CFTimeout` or `CFThought`), so the sender's bubble will appear and time out exactly like speedchat does. One line change.

Havent been able to do a live two-client test yet — my local env is missing the Panda3D 1.11 / Python 3.9 toolchain to run two clients against a local UberDOG. Anyone with a working dev env should be able to confirm in a few seconds by typing a message and watching their own nametag.