### PR TITLE
Fix golf course join-barrier cleanup on disconnect

### DIFF
--- a/toontown/golf/DistributedGolfCourseAI.py
+++ b/toontown/golf/DistributedGolfCourseAI.py
@@ -188,9 +188,8 @@ class DistributedGolfCourseAI(DistributedObjectAI.DistributedObjectAI, FSM):
         if hasattr(self, 'rewardBarrier'):
             if self.rewardBarrier:
                 self.rewardBarrier.clear(avId)
-        if hasattr(self, '__barrier'):
-            if self.__barrier:
-                self.__.clear(avId)
+        if self.__barrier:
+            self.__barrier.clear(avId)
 
     def startNextHole(self):
         self.notify.debugStateCall(self)


### PR DESCRIPTION
`DistributedGolfCourseAI.avatarExited` tries to clean up `self.__barrier` when a player drops but the guard is broken two ways:

```python
if hasattr(self, '__barrier'):
    if self.__barrier:
        self.__.clear(avId)
```

First, Python name-mangles `self.__barrier` to `self._DistributedGolfCourseAI__barrier` inside the class, but the `hasattr` string is a plain `"__barrier"` so it's always `False` and the whole block never runs. The author got this right at line 256 with the mangled form. Second, `self.__.clear(...)` is a typo for `self.__barrier.clear(...)` — would `AttributeError` if it ever executed.

`self.__barrier` is initialized to `None` at line 63 so the attribute always exists. Fix just replaces the broken hasattr+typo with a plain truthy check and the correct call.

Result: a player disconnecting during the "wait for clients to join" phase now gets removed from the barrier so the remaining players can proceed instead of sitting there until `JOIN_TIMEOUT`.