### PR TITLE
Fix golf WaitReadyHole barrier cleanup guard

### DIFF
--- a/toontown/golf/DistributedGolfCourseAI.py
+++ b/toontown/golf/DistributedGolfCourseAI.py
@@ -326,7 +326,7 @@ class DistributedGolfCourseAI(DistributedObjectAI.DistributedObjectAI, FSM):
 
     def exitWaitReadyHole(self):
         self.notify.debugStateCall(self)
-        if hasattr(self, '__barrier'):
+        if self.__barrier:
             self.__barrier.cleanup()
             self.__barrier = None
         return


### PR DESCRIPTION
`exitWaitReadyHole` guards its barrier cleanup with `hasattr(self, '__barrier')`, but the attribute is name-mangled inside the class to `_DistributedGolfCourseAI__barrier`. The unmangled string never matches, so the check is always False and the cleanup body never runs. The `WaitReadyHole` barrier created in `enterWaitReadyHole` is leaked every time the FSM leaves that state.

`self.__barrier` is initialized to `None` in `__init__`, so the correct guard is just the value: `if self.__barrier:`. That matches what `exitWaitJoin` already does, and the same pattern in the disconnect path I touched in #137.

This is the same name-mangling mistake as #137, just in a different method of the same file. Filing it separately so each is a clean one-line review. Note line ~256 in this file uses the correct `hasattr(self, '_DistributedGolfCourseAI__barrier')` form, so the file was simply inconsistent.