### PR TITLE
Return card name from PlayingCardBase.getCardName

### DIFF
--- a/toontown/minigame/PlayingCard.py
+++ b/toontown/minigame/PlayingCard.py
@@ -11,7 +11,7 @@ class PlayingCardBase:
         self.setValue(value)
 
     def getCardName(self):
-        PlayingCardGlobals.getCardName(self.value)
+        return PlayingCardGlobals.getCardName(self.value)
 
     def getRank(self):
         return self.rank


### PR DESCRIPTION
`PlayingCardBase.getCardName` calls `PlayingCardGlobals.getCardName(self.value)` but drops the result, so the method always returns `None` instead of the localized card name.

The sibling accessors right below it all return their value:
```python
def getRank(self):
    return self.rank

def getSuit(self):
    return self.suit

def getValue(self):
    return self.value
```
and no subclass (`PlayingCardNodePath`, `PlayingCardButton`) overrides `getCardName`, so the missing `return` is clearly an oversight rather than an intentional abstract stub.

No call sites use the return value in the current tree, so this is not an active crash, just a one-line fix so the accessor actually works for anyone who reaches for it later.