### PR TITLE
Fix format-string arg errors in battle notifies

### DIFF
--- a/toontown/coghq/DistributedLevelBattle.py
+++ b/toontown/coghq/DistributedLevelBattle.py
@@ -41,7 +41,7 @@ class DistributedLevelBattle(DistributedBattle.DistributedBattle):
 
         level = base.cr.doId2do.get(self.levelDoId)
         if level is None:
-            self.notify.warning('level %s not in doId2do yet, battle %s will be mispositioned.' % self.levelDoId, self.doId)
+            self.notify.warning('level %s not in doId2do yet, battle %s will be mispositioned.' % (self.levelDoId, self.doId))
             self.levelRequest = self.cr.relatedObjectMgr.requestObjects([self.levelDoId], doPlacement)
         else:
             doPlacement([level])

--- a/toontown/town/TownBattleAttackPanel.py
+++ b/toontown/town/TownBattleAttackPanel.py
@@ -77,7 +77,7 @@ class TownBattleAttackPanel(StateData.StateData):
             doneStatus['level'] = level
             messenger.send(self.doneEvent, [doneStatus])
         else:
-            self.notify.error("An item we don't have: track %s level %s was selected." % [track, level])
+            self.notify.error("An item we don't have: track %s level %s was selected." % (track, level))
 
     def __handleHide(self):
         if AttackPanelHidden:


### PR DESCRIPTION
Two `notify` calls raise `TypeError` instead of logging when their branch executes, because the `%` operand count is wrong.

**`toontown/coghq/DistributedLevelBattle.py`** (`doPlacement`, level not yet in `doId2do`):
```python
self.notify.warning('level %s not in doId2do yet, battle %s will be mispositioned.' % self.levelDoId, self.doId)
```
`%` binds tighter than the comma, so this formats two `%s` specifiers against the single int `self.levelDoId` (`TypeError: not enough arguments for format string`) and silently passes `self.doId` as a second positional arg to `warning()`. This is a reachable AI path when a battle generates before its level object resolves. Fixed by wrapping both operands in a tuple.

**`toontown/town/TownBattleAttackPanel.py`** (`__handleInventory`, item with no inventory):
```python
self.notify.error("An item we don't have: track %s level %s was selected." % [track, level])
```
The operand is a list; `%` only unpacks a tuple, so two `%s` against one operand crashes with `TypeError` before the intended error message is built. Changed to a tuple.

Both are one-character/operand fixes; no behavior change beyond the messages now formatting correctly.