### PR TITLE
Use // where Python 2 int division was assumed

### DIFF
--- a/toontown/fishing/DiagonalBingo.py
+++ b/toontown/fishing/DiagonalBingo.py
@@ -24,7 +24,7 @@ class DiagonalBingo(BingoCardBase.BingoCardBase):
         return self.onFDiag(id) | self.onBDiag(id)
 
     def checkForBingo(self):
-        id = self.cardSize / 2
+        id = self.cardSize // 2
         if self.checkForWin(id):
             return BingoGlobals.WIN
         return BingoGlobals.NO_UPDATE

--- a/toontown/fishing/NormalBingo.py
+++ b/toontown/fishing/NormalBingo.py
@@ -24,11 +24,11 @@ class NormalBingo(BingoCardBase.BingoCardBase):
         return 1
 
     def checkForBingo(self):
-        id = self.cardSize / 2
+        id = self.cardSize // 2
         if self.checkForWin(id):
             return BingoGlobals.WIN
         for i in range(BingoGlobals.CARD_ROWS):
-            if i != BingoGlobals.CARD_ROWS / 2:
+            if i != BingoGlobals.CARD_ROWS // 2:
                 rowResult = self.rowCheck(i)
                 colResult = self.colCheck(i)
                 if rowResult | colResult:

--- a/toontown/fishing/ThreewayBingo.py
+++ b/toontown/fishing/ThreewayBingo.py
@@ -29,7 +29,7 @@ class ThreewayBingo(BingoCardBase.BingoCardBase):
         return self.onRow(2, id) | self.onFDiag(id) | self.onBDiag(id)
 
     def checkForBingo(self):
-        id = self.cardSize / 2
+        id = self.cardSize // 2
         if self.checkForWin(id):
             return BingoGlobals.WIN
         return BingoGlobals.NO_UPDATE

--- a/toontown/safezone/Train.py
+++ b/toontown/safezone/Train.py
@@ -112,7 +112,7 @@ class Train(DirectObject):
         nextRun = Sequence(Func(self.__showStart))
         if trainShouldStop == 0:
             waitTime = 3
-            totalTime = random.randrange(4, (self.MarkDelta - waitTime) / 2)
+            totalTime = random.randrange(4, (self.MarkDelta - waitTime) // 2)
             sfxStopTime = 4.3
             halfway = (self.trackStartPos + self.trackEndPos) / 2
             halfway.setX(150)

--- a/toontown/shtiker/EventsPage.py
+++ b/toontown/shtiker/EventsPage.py
@@ -779,7 +779,7 @@ class EventsPage(ShtikerPage.ShtikerPage):
         urlStrings = urlfile.read()
         urlfile.close()
         urls = urlStrings.split('\r\n')
-        for index in range(len(urls) / 2):
+        for index in range(len(urls) // 2):
             imageUrl = urls[index * 2]
             textUrl = urls[index * 2 + 1]
             img = PNMImage()


### PR DESCRIPTION
Several spots ported from Python 2 use `/` on integers and feed the result somewhere that requires an int. In Python 3 `/` is true division and returns a `float`, so these raise `TypeError` when the line executes.

**`toontown/fishing/NormalBingo.py`** (and `DiagonalBingo`, `ThreewayBingo`) - `checkForBingo`:
```python
id = self.cardSize / 2   # 25 / 2 -> 12.5
```
In `NormalBingo` that float flows through `checkForWin` (`colId = id % CARD_COLS` -> `2.5`) into `BingoCardBase.colCheck`, where `1 << self.rowSize * rowId + colId` does `1 << <float>` and raises `TypeError: unsupported operand type(s) for <<`. This fires when a player presses the BINGO button on a normal card during a Fish Bingo event. Also fixed `if i != BingoGlobals.CARD_ROWS / 2:` so the center-cell skip compares ints.

**`toontown/safezone/Train.py`** - `__getNextRun`:
```python
totalTime = random.randrange(4, (self.MarkDelta - waitTime) / 2)
```
`(15 - 3) / 2 = 6.0`; `random.randrange` rejects a float bound with `TypeError`. Reachable on the Cashbot HQ exterior train when it stops.

**`toontown/shtiker/EventsPage.py`** - `downloadArticlesTask`:
```python
for index in range(len(urls) / 2):
```
`range()` rejects a float. On the blocking news-download path.

All changed from `/` to `//`. The bingo `/ 2` in the center-skip and the others are integer by intent (card indices, retry counts, article pairs).