### PR TITLE
Replace removed Python 2 string-module functions

### DIFF
--- a/otp/chat/ChatGlobals.py
+++ b/otp/chat/ChatGlobals.py
@@ -40,7 +40,7 @@ ThoughtPrefix = '.'
 def isThought(message):
     if len(message) == 0:
         return 0
-    elif string.find(message, ThoughtPrefix, 0, len(ThoughtPrefix)) >= 0:
+    elif message.find(ThoughtPrefix, 0, len(ThoughtPrefix)) >= 0:
         return 1
     else:
         return 0

--- a/otp/chat/ChatManager.py
+++ b/otp/chat/ChatManager.py
@@ -22,7 +22,7 @@ ThoughtPrefix = '.'
 def isThought(message):
     if len(message) == 0:
         return 0
-    elif string.find(message, ThoughtPrefix, 0, len(ThoughtPrefix)) >= 0:
+    elif message.find(ThoughtPrefix, 0, len(ThoughtPrefix)) >= 0:
         return 1
     else:
         return 0

--- a/otp/level/LevelSpec.py
+++ b/otp/level/LevelSpec.py
@@ -306,7 +306,7 @@ class LevelSpec:
                 entType2ids = self.getEntType2ids(entIds)
                 types = sortList(list(entType2ids.keys()), firstTypes)
                 for type in types:
-                    str += t(1) + '# %s\n' % string.upper(type)
+                    str += t(1) + '# %s\n' % type.upper()
                     entIds = entType2ids[type]
                     entIds.sort()
                     for entId in entIds:

--- a/toontown/pets/DistributedPetProxy.py
+++ b/toontown/pets/DistributedPetProxy.py
@@ -25,7 +25,7 @@ class DistributedPetProxy(DistributedObject.DistributedObject):
         self.requiredMoodComponents = {}
 
     def getSetterName(self, valueName, prefix = 'set'):
-        return '%s%s%s' % (prefix, string.upper(valueName[0]), valueName[1:])
+        return '%s%s%s' % (prefix, valueName[0].upper(), valueName[1:])
 
     def setOwnerId(self, ownerId):
         self.ownerId = ownerId

--- a/toontown/pets/DistributedPetProxyAI.py
+++ b/toontown/pets/DistributedPetProxyAI.py
@@ -37,7 +37,7 @@ class DistributedPetProxyAI(DistributedObjectAI.DistributedObjectAI):
         self.__generateDistMoodFuncs()
 
     def getSetterName(self, valueName, prefix = 'set'):
-        return '%s%s%s' % (prefix, string.upper(valueName[0]), valueName[1:])
+        return '%s%s%s' % (prefix, valueName[0].upper(), valueName[1:])
 
     def setDNA(self, dna):
         head, ears, nose, tail, body, color, colorScale, eyes, gender = dna

--- a/toontown/pets/PetBase.py
+++ b/toontown/pets/PetBase.py
@@ -5,7 +5,7 @@ import string
 class PetBase:
 
     def getSetterName(self, valueName, prefix = 'set'):
-        return '%s%s%s' % (prefix, string.upper(valueName[0]), valueName[1:])
+        return '%s%s%s' % (prefix, valueName[0].upper(), valueName[1:])
 
     def getAnimMood(self):
         if self.mood.getDominantMood() in PetMood.PetMood.ExcitedMoods:

--- a/toontown/pets/PetshopGUI.py
+++ b/toontown/pets/PetshopGUI.py
@@ -358,7 +358,7 @@ class PetshopGUI(DirectObject):
                     descList.append('\t%s' % trait)
 
                 descList.append(TTLocalizer.PetshopDescCost % cost)
-                self.petDesc.append(string.join(descList, '\n'))
+                self.petDesc.append('\n'.join(descList))
                 self.petCost.append(cost)
 
         def destroy(self):

--- a/toontown/shtiker/PhotoAlbumPage.py
+++ b/toontown/shtiker/PhotoAlbumPage.py
@@ -4,6 +4,7 @@ from direct.gui.DirectGui import *
 from panda3d.core import *
 from toontown.toonbase import TTLocalizer
 import os
+import string
 from toontown.toonbase import ToontownGlobals
 
 class PhotoAlbumPage(ShtikerPage.ShtikerPage):
@@ -88,7 +89,7 @@ class PhotoAlbumPage(ShtikerPage.ShtikerPage):
 
     def renameDialog(self, str):
         separator = '_'
-        validChars = string.letters + string.digits + ' -'
+        validChars = string.ascii_letters + string.digits + ' -'
         str = [s for s in str if s in validChars]
         if not str:
             self.renameCleanup()


### PR DESCRIPTION
`string.find`, `string.upper`, `string.join`, and `string.letters` were removed from the `string` module in Python 3 (the function forms became `str` methods; `string.letters` became `string.ascii_letters`). These call sites raise `AttributeError` (or `NameError`) when their line runs. Replaced each with the `str`-method equivalent:

- **`otp/chat/ChatGlobals.py`, `otp/chat/ChatManager.py`** - `isThought`: `string.find(message, ThoughtPrefix, ...)` -> `message.find(ThoughtPrefix, ...)`. (These are the module-level copies; the live chat path uses `TalkAssistant.isThought`, which already uses `message.find`, so these are the lesser-trodden duplicates, but still broken if reached.)
- **`otp/level/LevelSpec.py`**: `string.upper(type)` -> `type.upper()`.
- **`toontown/pets/PetBase.py`, `DistributedPetProxyAI.py`, `DistributedPetProxy.py`** - `getSetterName`: `string.upper(valueName[0])` -> `valueName[0].upper()`.
- **`toontown/pets/PetshopGUI.py`**: `string.join(descList, '\n')` -> `'\n'.join(descList)`.
- **`toontown/shtiker/PhotoAlbumPage.py`** - `renameDialog`: `string.letters` -> `string.ascii_letters`, and added the missing `import string` (the file referenced `string` without importing it).

`string.capwords` and `string.digits` are still present in the Py3 `string` module, so `QuestPoster`'s `capwords` usage is intentionally left alone.

Note: `otp/level/EntityTypeRegistry.py` also has `string.join`, but on the same lines it uses the removed `file()` builtin too, so it needs a separate `file()` -> `open()` fix; left out of this PR to keep it focused.