### PR TITLE
Avoid shared mutable default for race qualTimes

### DIFF
--- a/toontown/racing/DistributedRaceAI.py
+++ b/toontown/racing/DistributedRaceAI.py
@@ -11,7 +11,7 @@ from direct.distributed.ClockDelta import *
 class DistributedRaceAI(DistributedObjectAI.DistributedObjectAI):
     notify = DirectNotifyGlobal.directNotify.newCategory('DistributedRaceAI')
 
-    def __init__(self, air, trackId, zoneId, avIds, laps, raceType, racerFinishedFunc, raceDoneFunc, circuitLoop, circuitPoints, circuitTimes, qualTimes=[], circuitTimeList={}, circuitTotalBonusTickets={}):
+    def __init__(self, air, trackId, zoneId, avIds, laps, raceType, racerFinishedFunc, raceDoneFunc, circuitLoop, circuitPoints, circuitTimes, qualTimes=None, circuitTimeList={}, circuitTotalBonusTickets={}):
         DistributedObjectAI.DistributedObjectAI.__init__(self, air)
         self.trackId = trackId
         self.direction = self.trackId % 2
@@ -44,7 +44,7 @@ class DistributedRaceAI(DistributedObjectAI.DistributedObjectAI):
             self.gagList = [
              0] * len(RaceGlobals.TrackDict[trackId][4])
         self.circuitLoop = circuitLoop
-        self.qualTimes = qualTimes
+        self.qualTimes = qualTimes if qualTimes is not None else []
         self.circuitTimeList = circuitTimeList
         self.qualTimes.append(RaceGlobals.TrackDict[trackId][1])
         self.circuitTotalBonusTickets = circuitTotalBonusTickets

--- a/toontown/racing/RaceManagerAI.py
+++ b/toontown/racing/RaceManagerAI.py
@@ -21,7 +21,7 @@ class RaceManagerAI(DirectObject.DirectObject):
     def getDoId(self):
         return 0
 
-    def createRace(self, trackId, raceType, laps, players, circuitLoop, circuitPoints, circuitTimes, qualTimes=[], circuitTimeList={}, circuitTotalBonusTickets={}):
+    def createRace(self, trackId, raceType, laps, players, circuitLoop, circuitPoints, circuitTimes, qualTimes=None, circuitTimeList={}, circuitTotalBonusTickets={}):
         raceZone = self.air.allocateZone()
         race = DistributedRaceAI.DistributedRaceAI(self.air, trackId, raceZone, players, laps, raceType, self.exitedRace, self.raceOver, circuitLoop, circuitPoints, circuitTimes, qualTimes, circuitTimeList, circuitTotalBonusTickets)
         race.generateWithRequired(raceZone)


### PR DESCRIPTION
`DistributedRaceAI.__init__` defaults `qualTimes=[]` and then does:
```python
self.qualTimes = qualTimes
...
self.qualTimes.append(RaceGlobals.TrackDict[trackId][1])
```
A default argument list is created once, at function-definition time, and shared by every call that doesn't pass its own. So every race started without an explicit `qualTimes` appends to the *same* list, and it grows by one entry per race for the lifetime of the AI process, leaking qualifying-time state across unrelated races.

`RaceManagerAI.createRace` has the same `qualTimes=[]` default and forwards it into `DistributedRaceAI`, so races created from a race pad (which don't pass `qualTimes`) hit exactly this path.

Switched both defaults to `None` and build a fresh list inside `DistributedRaceAI` when none is supplied. (Left the `circuitTimeList={}` / `circuitTotalBonusTickets={}` defaults alone, those aren't mutated in place.)